### PR TITLE
Relax default template ade-engine pinning

### DIFF
--- a/src/ade_engine/extensions/templates/config_packages/default/pyproject.toml
+++ b/src/ade_engine/extensions/templates/config_packages/default/pyproject.toml
@@ -7,7 +7,8 @@ requires-python = ">=3.11"
 dependencies = [
   "openpyxl==3.1.5",
   "polars==1.36.1",
-  "ade-engine",
+  # Prefer pinning (e.g., ==1.7.x) when deploying to production.
+  "ade-engine>=1.7.9",
 ]
 
 [build-system]


### PR DESCRIPTION
Summary
- loosen the default template dependency to require `ade-engine>=1.7.9` and add a comment encouraging pinning for production

Testing
- Not run (not requested)