### PR TITLE
feat(pipeline): implement merging of tables with type coercion and error handling

### DIFF
--- a/src/ade_engine/application/pipeline/pipeline.py
+++ b/src/ade_engine/application/pipeline/pipeline.py
@@ -15,8 +15,9 @@ from ade_engine.application.pipeline.validate import apply_validators
 from ade_engine.extensions.registry import Registry
 from ade_engine.infrastructure.observability.logger import RunLogger
 from ade_engine.infrastructure.settings import Settings
+from ade_engine.models.errors import PipelineError
 from ade_engine.models.extension_contexts import HookName
-from ade_engine.models.table import TableRegion, TableResult
+from ade_engine.models.table import MappedColumn, SourceColumn, TableRegion, TableResult
 
 
 def _stringify_cell(value: Any) -> str | None:
@@ -170,6 +171,210 @@ def _ordered_column_union(tables: list[TableResult]) -> list[str]:
     return ordered
 
 
+def _resolve_merged_column_order(tables: list[TableResult]) -> list[str]:
+    return _ordered_column_union(tables)
+
+
+def _is_integer_dtype(dtype: pl.DataType) -> bool:
+    return dtype in {
+        pl.Int8,
+        pl.Int16,
+        pl.Int32,
+        pl.Int64,
+        pl.UInt8,
+        pl.UInt16,
+        pl.UInt32,
+        pl.UInt64,
+    }
+
+
+def _is_float_dtype(dtype: pl.DataType) -> bool:
+    return dtype in {pl.Float32, pl.Float64}
+
+
+def _dtype_sort_key(dtype: pl.DataType) -> str:
+    return repr(dtype)
+
+
+def _resolve_merged_column_dtype(column_name: str, tables: list[TableResult]) -> pl.DataType:
+    observed: list[pl.DataType] = []
+    concrete: list[pl.DataType] = []
+    for table_result in tables:
+        schema = table_result.table.schema
+        if column_name not in schema:
+            continue
+        dtype = schema[column_name]
+        observed.append(dtype)
+        if dtype != pl.Null:
+            concrete.append(dtype)
+
+    if not observed:
+        return pl.Null
+    if not concrete:
+        return pl.Null
+
+    unique_concrete = {dtype for dtype in concrete}
+    if len(unique_concrete) == 1:
+        return next(iter(unique_concrete))
+
+    if all(_is_integer_dtype(dtype) or _is_float_dtype(dtype) for dtype in unique_concrete):
+        return pl.Float64
+
+    if unique_concrete == {pl.Date, pl.Datetime} or unique_concrete == {pl.Datetime, pl.Date}:
+        return pl.Datetime("us")
+
+    dtype_list = ", ".join(sorted({_dtype_sort_key(dtype) for dtype in observed}))
+    raise PipelineError(
+        f"Failed to merge in-sheet tables: incompatible dtypes for column '{column_name}' ({dtype_list})"
+    )
+
+
+def _align_table_for_merge(
+    table_result: TableResult,
+    column_order: list[str],
+    dtype_by_column: dict[str, pl.DataType],
+) -> pl.DataFrame:
+    table = table_result.table
+    for column_name in column_order:
+        target_dtype = dtype_by_column[column_name]
+        if column_name in table.columns:
+            current_dtype = table.schema[column_name]
+            if current_dtype != target_dtype:
+                table = table.with_columns(pl.col(column_name).cast(target_dtype, strict=False))
+            continue
+        table = table.with_columns(pl.lit(None, dtype=target_dtype).alias(column_name))
+    return table.select(column_order)
+
+
+def _first_non_empty_header(headers: list[Any]) -> Any:
+    for header in headers:
+        if header not in (None, ""):
+            return header
+    return headers[0] if headers else None
+
+
+def _collect_source_headers_by_column_name(tables: list[TableResult]) -> dict[str, list[Any]]:
+    headers_by_name: dict[str, list[Any]] = {}
+    for table_result in tables:
+        for source_column in table_result.source_columns:
+            if not (0 <= source_column.index < len(table_result.table.columns)):
+                continue
+            column_name = table_result.table.columns[source_column.index]
+            headers_by_name.setdefault(column_name, []).append(source_column.header)
+    return headers_by_name
+
+
+def _build_merged_source_columns(
+    *,
+    merged_df: pl.DataFrame,
+    headers_by_name: dict[str, list[Any]],
+) -> list[SourceColumn]:
+    source_columns: list[SourceColumn] = []
+    for index, column_name in enumerate(merged_df.columns):
+        source_columns.append(
+            SourceColumn(
+                index=index,
+                header=_first_non_empty_header(headers_by_name.get(column_name, [])),
+                values=merged_df.get_column(column_name).to_list(),
+            )
+        )
+    return source_columns
+
+
+def _build_merged_mapped_columns(
+    *,
+    tables: list[TableResult],
+    merged_df: pl.DataFrame,
+) -> list[MappedColumn]:
+    merged_mapped: dict[str, MappedColumn] = {}
+    for table_result in tables:
+        for mapped in table_result.mapped_columns:
+            if mapped.field_name not in merged_df.columns:
+                continue
+            merged_values = merged_df.get_column(mapped.field_name).to_list()
+            existing = merged_mapped.get(mapped.field_name)
+            if existing is None:
+                merged_mapped[mapped.field_name] = MappedColumn(
+                    field_name=mapped.field_name,
+                    source_index=merged_df.columns.index(mapped.field_name),
+                    header=mapped.header,
+                    values=merged_values,
+                    score=mapped.score,
+                )
+                continue
+            header = existing.header if existing.header not in (None, "") else mapped.header
+            score_candidates = [score for score in (existing.score, mapped.score) if score is not None]
+            merged_mapped[mapped.field_name] = MappedColumn(
+                field_name=mapped.field_name,
+                source_index=existing.source_index,
+                header=header,
+                values=merged_values,
+                score=max(score_candidates) if score_candidates else None,
+            )
+    return sorted(merged_mapped.values(), key=lambda col: col.source_index)
+
+
+def _build_merged_column_scores(
+    *,
+    tables: list[TableResult],
+    merged_df: pl.DataFrame,
+) -> dict[int, dict[str, float]]:
+    merged_scores_by_name: dict[str, dict[str, float]] = {}
+    for table_result in tables:
+        for source_index, scores in table_result.column_scores.items():
+            if not (0 <= source_index < len(table_result.table.columns)):
+                continue
+            column_name = table_result.table.columns[source_index]
+            merged_scores = merged_scores_by_name.setdefault(column_name, {})
+            for field_name, score in scores.items():
+                current = merged_scores.get(field_name)
+                merged_scores[field_name] = score if current is None else max(current, score)
+
+    merged_scores: dict[int, dict[str, float]] = {}
+    for index, column_name in enumerate(merged_df.columns):
+        scores = merged_scores_by_name.get(column_name)
+        if scores:
+            merged_scores[index] = dict(scores)
+    return merged_scores
+
+
+def _build_merged_table_result(tables: list[TableResult], merged_df: pl.DataFrame) -> TableResult:
+    if not tables:
+        raise PipelineError("Failed to merge in-sheet tables: no tables provided")
+
+    sheet_name = tables[0].sheet_name
+    sheet_index = tables[0].sheet_index
+    if any(table.sheet_name != sheet_name for table in tables):
+        raise PipelineError("Failed to merge in-sheet tables: contributing tables span multiple sheets")
+    if any(table.sheet_index != sheet_index for table in tables):
+        raise PipelineError("Failed to merge in-sheet tables: contributing tables span multiple sheet indexes")
+
+    headers_by_name = _collect_source_headers_by_column_name(tables)
+    source_columns = _build_merged_source_columns(merged_df=merged_df, headers_by_name=headers_by_name)
+    mapped_columns = _build_merged_mapped_columns(tables=tables, merged_df=merged_df)
+    mapped_names = {column.field_name for column in mapped_columns}
+    unmapped_columns = [column for column in source_columns if merged_df.columns[column.index] not in mapped_names]
+    duplicate_unmapped_indices = {
+        source_column.index
+        for source_column in unmapped_columns
+        if source_column.index < len(merged_df.columns) and merged_df.columns[source_column.index] in mapped_names
+    }
+
+    return TableResult(
+        sheet_name=sheet_name,
+        table=merged_df,
+        source_region=_merge_source_regions(tables),
+        source_columns=source_columns,
+        table_index=0,
+        sheet_index=sheet_index,
+        mapped_columns=mapped_columns,
+        unmapped_columns=unmapped_columns,
+        column_scores=_build_merged_column_scores(tables=tables, merged_df=merged_df),
+        duplicate_unmapped_indices=duplicate_unmapped_indices,
+        row_count=merged_df.height,
+    )
+
+
 def _merge_source_regions(tables: list[TableResult]) -> TableRegion:
     regions = [table.source_region for table in tables if isinstance(table.source_region, TableRegion)]
     if not regions:
@@ -195,25 +400,21 @@ def _merge_tables_in_sheet(tables: list[TableResult]) -> list[TableResult]:
     if len(tables) <= 1:
         return tables
 
-    merged = pl.concat([table.table for table in tables], how="diagonal")
-    ordered_columns = _ordered_column_union(tables)
-    if ordered_columns:
-        merged = merged.select(ordered_columns)
+    column_order = _resolve_merged_column_order(tables)
+    dtype_by_column = {column_name: _resolve_merged_column_dtype(column_name, tables) for column_name in column_order}
 
-    template = tables[0]
-    merged_result = TableResult(
-        sheet_name=template.sheet_name,
-        table=merged,
-        source_region=_merge_source_regions(tables),
-        source_columns=template.source_columns,
-        table_index=0,
-        sheet_index=template.sheet_index,
-        mapped_columns=template.mapped_columns,
-        unmapped_columns=template.unmapped_columns,
-        column_scores=template.column_scores,
-        duplicate_unmapped_indices=set(template.duplicate_unmapped_indices),
-        row_count=merged.height,
-    )
+    try:
+        aligned_tables = [
+            _align_table_for_merge(table_result=table_result, column_order=column_order, dtype_by_column=dtype_by_column)
+            for table_result in tables
+        ]
+        merged = pl.concat(aligned_tables, how="vertical") if aligned_tables else pl.DataFrame()
+    except PipelineError:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive normalization around Polars internals
+        raise PipelineError(f"Failed to merge in-sheet tables: {exc}") from exc
+
+    merged_result = _build_merged_table_result(tables, merged)
     return [merged_result]
 
 

--- a/src/ade_engine/application/pipeline/pipeline.py
+++ b/src/ade_engine/application/pipeline/pipeline.py
@@ -192,6 +192,50 @@ def _is_float_dtype(dtype: pl.DataType) -> bool:
     return dtype in {pl.Float32, pl.Float64}
 
 
+def _integer_dtype_width(dtype: pl.DataType) -> int:
+    widths = {
+        pl.Int8: 8,
+        pl.Int16: 16,
+        pl.Int32: 32,
+        pl.Int64: 64,
+        pl.UInt8: 8,
+        pl.UInt16: 16,
+        pl.UInt32: 32,
+        pl.UInt64: 64,
+    }
+    return widths[dtype]
+
+
+def _is_signed_integer_dtype(dtype: pl.DataType) -> bool:
+    return dtype in {pl.Int8, pl.Int16, pl.Int32, pl.Int64}
+
+
+def _resolve_integer_supertype(dtypes: set[pl.DataType]) -> pl.DataType:
+    if all(_is_signed_integer_dtype(dtype) for dtype in dtypes):
+        widest = max(_integer_dtype_width(dtype) for dtype in dtypes)
+        return {8: pl.Int8, 16: pl.Int16, 32: pl.Int32, 64: pl.Int64}[widest]
+
+    if all(not _is_signed_integer_dtype(dtype) for dtype in dtypes):
+        widest = max(_integer_dtype_width(dtype) for dtype in dtypes)
+        return {8: pl.UInt8, 16: pl.UInt16, 32: pl.UInt32, 64: pl.UInt64}[widest]
+
+    widest_unsigned = max(_integer_dtype_width(dtype) for dtype in dtypes if not _is_signed_integer_dtype(dtype))
+    widest_signed = max(_integer_dtype_width(dtype) for dtype in dtypes if _is_signed_integer_dtype(dtype))
+
+    signed_candidates = (
+        (8, pl.Int8),
+        (16, pl.Int16),
+        (32, pl.Int32),
+        (64, pl.Int64),
+    )
+    required_signed_width = max(widest_signed, min(64, widest_unsigned * 2))
+    for width, dtype in signed_candidates:
+        if width >= required_signed_width:
+            return dtype
+
+    raise PipelineError("Failed to merge in-sheet tables: no safe integer supertype for signed/unsigned mix")
+
+
 def _dtype_sort_key(dtype: pl.DataType) -> str:
     return repr(dtype)
 
@@ -216,6 +260,15 @@ def _resolve_merged_column_dtype(column_name: str, tables: list[TableResult]) ->
     unique_concrete = {dtype for dtype in concrete}
     if len(unique_concrete) == 1:
         return next(iter(unique_concrete))
+
+    if all(_is_integer_dtype(dtype) for dtype in unique_concrete):
+        try:
+            return _resolve_integer_supertype(unique_concrete)
+        except PipelineError as exc:
+            dtype_list = ", ".join(sorted({_dtype_sort_key(dtype) for dtype in observed}))
+            raise PipelineError(
+                f"Failed to merge in-sheet tables: incompatible dtypes for column '{column_name}' ({dtype_list})"
+            ) from exc
 
     if all(_is_integer_dtype(dtype) or _is_float_dtype(dtype) for dtype in unique_concrete):
         return pl.Float64
@@ -354,10 +407,14 @@ def _build_merged_table_result(tables: list[TableResult], merged_df: pl.DataFram
     mapped_columns = _build_merged_mapped_columns(tables=tables, merged_df=merged_df)
     mapped_names = {column.field_name for column in mapped_columns}
     unmapped_columns = [column for column in source_columns if merged_df.columns[column.index] not in mapped_names]
+    duplicate_unmapped_names: set[str] = set()
+    for table_result in tables:
+        for source_index in table_result.duplicate_unmapped_indices:
+            if 0 <= source_index < len(table_result.table.columns):
+                duplicate_unmapped_names.add(table_result.table.columns[source_index])
+
     duplicate_unmapped_indices = {
-        source_column.index
-        for source_column in unmapped_columns
-        if source_column.index < len(merged_df.columns) and merged_df.columns[source_column.index] in mapped_names
+        index for index, column_name in enumerate(merged_df.columns) if column_name in duplicate_unmapped_names
     }
 
     return TableResult(

--- a/tests/unit/test_pipeline_multi_table.py
+++ b/tests/unit/test_pipeline_multi_table.py
@@ -4,12 +4,13 @@ from openpyxl import Workbook
 import polars as pl
 import pytest
 
-from ade_engine.application.pipeline.pipeline import Pipeline
+from ade_engine.application.pipeline.pipeline import Pipeline, _merge_tables_in_sheet
 from ade_engine.extensions.registry import Registry
 from ade_engine.infrastructure.observability.logger import NullLogger
 from ade_engine.infrastructure.settings import Settings
 from ade_engine.models.errors import PipelineError
 from ade_engine.models.extension_contexts import FieldDef, RowKind
+from ade_engine.models.table import SourceColumn, TableRegion, TableResult
 
 
 def test_process_sheet_renders_multiple_tables_with_blank_row():
@@ -520,3 +521,58 @@ def test_on_table_written_receives_merged_metadata_for_merged_tables():
     assert source_headers["Email"] == mapped_indices["email"]
     assert source_headers["Name"] == mapped_indices["name"]
     assert state["source_region"] == "A1:A5"
+
+
+def test_merge_tables_in_sheet_preserves_integer_supertype_without_float_widening():
+    table_a = TableResult(
+        sheet_name="Sheet1",
+        table=pl.DataFrame({"member_id": pl.Series("member_id", [1], dtype=pl.Int32)}),
+        source_region=TableRegion(min_row=1, min_col=1, max_row=2, max_col=1),
+        source_columns=[SourceColumn(index=0, header="Member ID", values=[1])],
+        table_index=0,
+        sheet_index=0,
+        row_count=1,
+    )
+    table_b = TableResult(
+        sheet_name="Sheet1",
+        table=pl.DataFrame({"member_id": pl.Series("member_id", [2], dtype=pl.Int64)}),
+        source_region=TableRegion(min_row=4, min_col=1, max_row=5, max_col=1),
+        source_columns=[SourceColumn(index=0, header="Member ID", values=[2])],
+        table_index=1,
+        sheet_index=0,
+        row_count=1,
+    )
+
+    merged = _merge_tables_in_sheet([table_a, table_b])[0]
+
+    assert merged.table.schema["member_id"] == pl.Int64
+    assert merged.table.get_column("member_id").to_list() == [1, 2]
+
+
+def test_merge_tables_in_sheet_preserves_duplicate_unmapped_indices():
+    table_a = TableResult(
+        sheet_name="Sheet1",
+        table=pl.DataFrame({"Notes": ["alpha"]}),
+        source_region=TableRegion(min_row=1, min_col=1, max_row=2, max_col=1),
+        source_columns=[SourceColumn(index=0, header="Notes", values=["alpha"])],
+        table_index=0,
+        sheet_index=0,
+        unmapped_columns=[SourceColumn(index=0, header="Notes", values=["alpha"])],
+        duplicate_unmapped_indices={0},
+        row_count=1,
+    )
+    table_b = TableResult(
+        sheet_name="Sheet1",
+        table=pl.DataFrame({"Notes": ["beta"]}),
+        source_region=TableRegion(min_row=4, min_col=1, max_row=5, max_col=1),
+        source_columns=[SourceColumn(index=0, header="Notes", values=["beta"])],
+        table_index=1,
+        sheet_index=0,
+        unmapped_columns=[SourceColumn(index=0, header="Notes", values=["beta"])],
+        duplicate_unmapped_indices={0},
+        row_count=1,
+    )
+
+    merged = _merge_tables_in_sheet([table_a, table_b])[0]
+
+    assert merged.duplicate_unmapped_indices == {0}

--- a/tests/unit/test_pipeline_multi_table.py
+++ b/tests/unit/test_pipeline_multi_table.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from openpyxl import Workbook
+import polars as pl
+import pytest
 
 from ade_engine.application.pipeline.pipeline import Pipeline
 from ade_engine.extensions.registry import Registry
 from ade_engine.infrastructure.observability.logger import NullLogger
 from ade_engine.infrastructure.settings import Settings
+from ade_engine.models.errors import PipelineError
 from ade_engine.models.extension_contexts import FieldDef, RowKind
 
 
@@ -228,3 +231,292 @@ def test_on_table_written_receives_written_table_after_output_policies():
 
     headers = list(output_ws.iter_rows(min_row=1, max_row=1, max_col=2, values_only=True))[0]
     assert headers == ("email", "name")
+
+
+def test_merge_tables_in_sheet_merges_metadata_from_all_tables():
+    registry = Registry()
+    logger = NullLogger()
+
+    registry.register_field(FieldDef(name="email"))
+    registry.register_field(FieldDef(name="name"))
+
+    def detector(*, row_index, **_):
+        if row_index in (1, 4):
+            return {RowKind.HEADER.value: 1.0}
+        if row_index in (2, 5):
+            return {RowKind.DATA.value: 1.0}
+        return {}
+
+    def detect_email(*, column_header_original, **_):
+        return {"email": 1.0} if column_header_original.strip().lower() == "email" else {}
+
+    def detect_name(*, column_header_original, **_):
+        return {"name": 1.0} if column_header_original.strip().lower() == "name" else {}
+
+    registry.register_row_detector(detector, row_kind=RowKind.UNKNOWN.value, priority=0)
+    registry.register_column_detector(detect_email, field="email", priority=0)
+    registry.register_column_detector(detect_name, field="name", priority=0)
+    registry.finalize()
+
+    pipeline = Pipeline(
+        registry=registry,
+        settings=Settings(merge_tables_in_sheet=True, write_diagnostics_columns=False),
+        logger=logger,
+    )
+
+    source_wb = Workbook()
+    source_ws = source_wb.active
+    source_ws.title = "Sheet1"
+    source_ws.append(["Email"])
+    source_ws.append(["a@example.com"])
+    source_ws.append([])
+    source_ws.append(["Name"])
+    source_ws.append(["Alice"])
+
+    output_wb = Workbook()
+    output_wb.remove(output_wb.active)
+    output_ws = output_wb.create_sheet(title="Sheet1")
+
+    tables = pipeline.process_sheet(
+        sheet=source_ws,
+        output_sheet=output_ws,
+        state={},
+        metadata={"input_file": "input.xlsx", "sheet_index": 0},
+        input_file_name="input.xlsx",
+    )
+
+    assert len(tables) == 1
+    table = tables[0]
+    assert "email" in table.table.columns
+    assert "name" in table.table.columns
+    assert table.source_region.a1 == "A1:A5"
+    assert {column.field_name for column in table.mapped_columns} == {"email", "name"}
+    mapped_indices = {column.field_name: column.source_index for column in table.mapped_columns}
+    assert table.table.columns[mapped_indices["email"]] == "email"
+    assert table.table.columns[mapped_indices["name"]] == "name"
+    source_headers = {column.header: column.index for column in table.source_columns if column.header not in (None, "")}
+    assert source_headers["Email"] == mapped_indices["email"]
+    assert source_headers["Name"] == mapped_indices["name"]
+    score_columns = {table.table.columns[index]: scores for index, scores in table.column_scores.items()}
+    assert score_columns["email"] == {"email": 1.0}
+    assert score_columns["name"] == {"name": 1.0}
+
+    emitted = list(output_ws.iter_rows(min_row=1, max_row=4, max_col=2, values_only=True))
+    assert emitted == [
+        ("email", "name"),
+        ("a@example.com", None),
+        (None, None),
+        (None, "Alice"),
+    ]
+
+
+def test_merge_tables_in_sheet_coerces_null_and_string_columns():
+    registry = Registry()
+    logger = NullLogger()
+
+    def detector(*, row_index, **_):
+        if row_index in (1, 4):
+            return {RowKind.HEADER.value: 1.0}
+        if row_index in (2, 5):
+            return {RowKind.DATA.value: 1.0}
+        return {}
+
+    registry.register_row_detector(detector, row_kind=RowKind.UNKNOWN.value, priority=0)
+    registry.finalize()
+
+    pipeline = Pipeline(
+        registry=registry,
+        settings=Settings(merge_tables_in_sheet=True, write_diagnostics_columns=False),
+        logger=logger,
+    )
+
+    source_wb = Workbook()
+    source_ws = source_wb.active
+    source_ws.title = "Sheet1"
+    source_ws.append(["SIN", "Comments"])
+    source_ws.append(["123456789", None])
+    source_ws.append([])
+    source_ws.append(["SIN", "Comments"])
+    source_ws.append(["987654321", "NQ"])
+
+    output_wb = Workbook()
+    output_wb.remove(output_wb.active)
+    output_ws = output_wb.create_sheet(title="Sheet1")
+
+    tables = pipeline.process_sheet(
+        sheet=source_ws,
+        output_sheet=output_ws,
+        state={},
+        metadata={"input_file": "apr.xlsx", "sheet_index": 0},
+        input_file_name="apr.xlsx",
+    )
+
+    assert len(tables) == 1
+    assert tables[0].table.columns[0:2] == ["SIN", "Comments"]
+    assert tables[0].table.schema["Comments"] == pl.String
+
+    emitted = list(output_ws.iter_rows(min_row=1, max_row=4, max_col=2, values_only=True))
+    assert emitted == [
+        ("SIN", "Comments"),
+        ("123456789", None),
+        (None, None),
+        ("987654321", "NQ"),
+    ]
+
+
+def test_merge_tables_in_sheet_widens_numeric_types():
+    registry = Registry()
+    logger = NullLogger()
+
+    def detector(*, row_index, **_):
+        if row_index in (1, 4):
+            return {RowKind.HEADER.value: 1.0}
+        if row_index in (2, 5):
+            return {RowKind.DATA.value: 1.0}
+        return {}
+
+    registry.register_row_detector(detector, row_kind=RowKind.UNKNOWN.value, priority=0)
+    registry.finalize()
+
+    pipeline = Pipeline(
+        registry=registry,
+        settings=Settings(merge_tables_in_sheet=True, write_diagnostics_columns=False),
+        logger=logger,
+    )
+
+    source_wb = Workbook()
+    source_ws = source_wb.active
+    source_ws.title = "Sheet1"
+    source_ws.append(["Amount"])
+    source_ws.append([10])
+    source_ws.append([])
+    source_ws.append(["Amount"])
+    source_ws.append([2.5])
+
+    output_wb = Workbook()
+    output_wb.remove(output_wb.active)
+    output_ws = output_wb.create_sheet(title="Sheet1")
+
+    tables = pipeline.process_sheet(
+        sheet=source_ws,
+        output_sheet=output_ws,
+        state={},
+        metadata={"input_file": "input.xlsx", "sheet_index": 0},
+        input_file_name="input.xlsx",
+    )
+
+    assert len(tables) == 1
+    assert tables[0].table.schema["Amount"] == pl.Float64
+    assert tables[0].table.get_column("Amount").to_list() == [10.0, None, 2.5]
+
+
+def test_merge_tables_in_sheet_raises_clear_error_for_incompatible_types():
+    registry = Registry()
+    logger = NullLogger()
+
+    def detector(*, row_index, **_):
+        if row_index in (1, 4):
+            return {RowKind.HEADER.value: 1.0}
+        if row_index in (2, 5):
+            return {RowKind.DATA.value: 1.0}
+        return {}
+
+    registry.register_row_detector(detector, row_kind=RowKind.UNKNOWN.value, priority=0)
+    registry.finalize()
+
+    pipeline = Pipeline(
+        registry=registry,
+        settings=Settings(merge_tables_in_sheet=True, write_diagnostics_columns=False),
+        logger=logger,
+    )
+
+    source_wb = Workbook()
+    source_ws = source_wb.active
+    source_ws.title = "Sheet1"
+    source_ws.append(["Mixed"])
+    source_ws.append([True])
+    source_ws.append([])
+    source_ws.append(["Mixed"])
+    source_ws.append(["text"])
+
+    output_wb = Workbook()
+    output_wb.remove(output_wb.active)
+    output_ws = output_wb.create_sheet(title="Sheet1")
+
+    with pytest.raises(PipelineError, match=r"incompatible dtypes for column 'Mixed'"):
+        pipeline.process_sheet(
+            sheet=source_ws,
+            output_sheet=output_ws,
+            state={},
+            metadata={"input_file": "input.xlsx", "sheet_index": 0},
+            input_file_name="input.xlsx",
+        )
+
+
+def test_on_table_written_receives_merged_metadata_for_merged_tables():
+    registry = Registry()
+    logger = NullLogger()
+
+    registry.register_field(FieldDef(name="email"))
+    registry.register_field(FieldDef(name="name"))
+
+    def detector(*, row_index, **_):
+        if row_index in (1, 4):
+            return {RowKind.HEADER.value: 1.0}
+        if row_index in (2, 5):
+            return {RowKind.DATA.value: 1.0}
+        return {}
+
+    def detect_email(*, column_header_original, **_):
+        return {"email": 1.0} if column_header_original.strip().lower() == "email" else {}
+
+    def detect_name(*, column_header_original, **_):
+        return {"name": 1.0} if column_header_original.strip().lower() == "name" else {}
+
+    def capture_written(*, write_table, table_result, state, **_):
+        state["written_columns"] = list(write_table.columns)
+        state["mapped_columns"] = [(column.field_name, column.source_index) for column in table_result.mapped_columns]
+        state["source_columns"] = [(column.header, column.index) for column in table_result.source_columns]
+        state["source_region"] = table_result.source_region.a1
+
+    registry.register_row_detector(detector, row_kind=RowKind.UNKNOWN.value, priority=0)
+    registry.register_column_detector(detect_email, field="email", priority=0)
+    registry.register_column_detector(detect_name, field="name", priority=0)
+    registry.register_hook(capture_written, hook="on_table_written", priority=0)
+    registry.finalize()
+
+    pipeline = Pipeline(
+        registry=registry,
+        settings=Settings(merge_tables_in_sheet=True, write_diagnostics_columns=False),
+        logger=logger,
+    )
+
+    source_wb = Workbook()
+    source_ws = source_wb.active
+    source_ws.title = "Sheet1"
+    source_ws.append(["Email"])
+    source_ws.append(["a@example.com"])
+    source_ws.append([])
+    source_ws.append(["Name"])
+    source_ws.append(["Alice"])
+
+    output_wb = Workbook()
+    output_wb.remove(output_wb.active)
+    output_ws = output_wb.create_sheet(title="Sheet1")
+
+    state: dict = {}
+    pipeline.process_sheet(
+        sheet=source_ws,
+        output_sheet=output_ws,
+        state=state,
+        metadata={"input_file": "input.xlsx", "sheet_index": 0},
+        input_file_name="input.xlsx",
+    )
+
+    assert state["written_columns"] == ["email", "name"]
+    assert [field for field, _ in state["mapped_columns"]] == ["email", "name"]
+    source_headers = {header: index for header, index in state["source_columns"] if header not in (None, "")}
+    mapped_indices = dict(state["mapped_columns"])
+    assert source_headers["Email"] == mapped_indices["email"]
+    assert source_headers["Name"] == mapped_indices["name"]
+    assert state["source_region"] == "A1:A5"


### PR DESCRIPTION
## Summary
- make `merge_tables_in_sheet` align compatible schemas before concatenation and raise clear `PipelineError`s for incompatible dtype conflicts
- build merged `TableResult` metadata from all contributing tables instead of reusing only the first table's facts
- add regressions for issue #11 metadata consistency, APR-style `Null`/`String` merges, numeric widening, incompatible dtype failures, and merged hook metadata

## Testing
- `python -m pytest -q`
