### PR TITLE
fix: preserve .xls sheet selection semantics

### DIFF
--- a/src/ade_engine/application/pipeline/pipeline.py
+++ b/src/ade_engine/application/pipeline/pipeline.py
@@ -15,8 +15,9 @@ from ade_engine.application.pipeline.validate import apply_validators
 from ade_engine.extensions.registry import Registry
 from ade_engine.infrastructure.observability.logger import RunLogger
 from ade_engine.infrastructure.settings import Settings
+from ade_engine.models.errors import PipelineError
 from ade_engine.models.extension_contexts import HookName
-from ade_engine.models.table import TableRegion, TableResult
+from ade_engine.models.table import MappedColumn, SourceColumn, TableRegion, TableResult
 
 
 def _stringify_cell(value: Any) -> str | None:
@@ -170,6 +171,210 @@ def _ordered_column_union(tables: list[TableResult]) -> list[str]:
     return ordered
 
 
+def _resolve_merged_column_order(tables: list[TableResult]) -> list[str]:
+    return _ordered_column_union(tables)
+
+
+def _is_integer_dtype(dtype: pl.DataType) -> bool:
+    return dtype in {
+        pl.Int8,
+        pl.Int16,
+        pl.Int32,
+        pl.Int64,
+        pl.UInt8,
+        pl.UInt16,
+        pl.UInt32,
+        pl.UInt64,
+    }
+
+
+def _is_float_dtype(dtype: pl.DataType) -> bool:
+    return dtype in {pl.Float32, pl.Float64}
+
+
+def _dtype_sort_key(dtype: pl.DataType) -> str:
+    return repr(dtype)
+
+
+def _resolve_merged_column_dtype(column_name: str, tables: list[TableResult]) -> pl.DataType:
+    observed: list[pl.DataType] = []
+    concrete: list[pl.DataType] = []
+    for table_result in tables:
+        schema = table_result.table.schema
+        if column_name not in schema:
+            continue
+        dtype = schema[column_name]
+        observed.append(dtype)
+        if dtype != pl.Null:
+            concrete.append(dtype)
+
+    if not observed:
+        return pl.Null
+    if not concrete:
+        return pl.Null
+
+    unique_concrete = {dtype for dtype in concrete}
+    if len(unique_concrete) == 1:
+        return next(iter(unique_concrete))
+
+    if all(_is_integer_dtype(dtype) or _is_float_dtype(dtype) for dtype in unique_concrete):
+        return pl.Float64
+
+    if unique_concrete == {pl.Date, pl.Datetime} or unique_concrete == {pl.Datetime, pl.Date}:
+        return pl.Datetime("us")
+
+    dtype_list = ", ".join(sorted({_dtype_sort_key(dtype) for dtype in observed}))
+    raise PipelineError(
+        f"Failed to merge in-sheet tables: incompatible dtypes for column '{column_name}' ({dtype_list})"
+    )
+
+
+def _align_table_for_merge(
+    table_result: TableResult,
+    column_order: list[str],
+    dtype_by_column: dict[str, pl.DataType],
+) -> pl.DataFrame:
+    table = table_result.table
+    for column_name in column_order:
+        target_dtype = dtype_by_column[column_name]
+        if column_name in table.columns:
+            current_dtype = table.schema[column_name]
+            if current_dtype != target_dtype:
+                table = table.with_columns(pl.col(column_name).cast(target_dtype, strict=False))
+            continue
+        table = table.with_columns(pl.lit(None, dtype=target_dtype).alias(column_name))
+    return table.select(column_order)
+
+
+def _first_non_empty_header(headers: list[Any]) -> Any:
+    for header in headers:
+        if header not in (None, ""):
+            return header
+    return headers[0] if headers else None
+
+
+def _collect_source_headers_by_column_name(tables: list[TableResult]) -> dict[str, list[Any]]:
+    headers_by_name: dict[str, list[Any]] = {}
+    for table_result in tables:
+        for source_column in table_result.source_columns:
+            if not (0 <= source_column.index < len(table_result.table.columns)):
+                continue
+            column_name = table_result.table.columns[source_column.index]
+            headers_by_name.setdefault(column_name, []).append(source_column.header)
+    return headers_by_name
+
+
+def _build_merged_source_columns(
+    *,
+    merged_df: pl.DataFrame,
+    headers_by_name: dict[str, list[Any]],
+) -> list[SourceColumn]:
+    source_columns: list[SourceColumn] = []
+    for index, column_name in enumerate(merged_df.columns):
+        source_columns.append(
+            SourceColumn(
+                index=index,
+                header=_first_non_empty_header(headers_by_name.get(column_name, [])),
+                values=merged_df.get_column(column_name).to_list(),
+            )
+        )
+    return source_columns
+
+
+def _build_merged_mapped_columns(
+    *,
+    tables: list[TableResult],
+    merged_df: pl.DataFrame,
+) -> list[MappedColumn]:
+    merged_mapped: dict[str, MappedColumn] = {}
+    for table_result in tables:
+        for mapped in table_result.mapped_columns:
+            if mapped.field_name not in merged_df.columns:
+                continue
+            merged_values = merged_df.get_column(mapped.field_name).to_list()
+            existing = merged_mapped.get(mapped.field_name)
+            if existing is None:
+                merged_mapped[mapped.field_name] = MappedColumn(
+                    field_name=mapped.field_name,
+                    source_index=merged_df.columns.index(mapped.field_name),
+                    header=mapped.header,
+                    values=merged_values,
+                    score=mapped.score,
+                )
+                continue
+            header = existing.header if existing.header not in (None, "") else mapped.header
+            score_candidates = [score for score in (existing.score, mapped.score) if score is not None]
+            merged_mapped[mapped.field_name] = MappedColumn(
+                field_name=mapped.field_name,
+                source_index=existing.source_index,
+                header=header,
+                values=merged_values,
+                score=max(score_candidates) if score_candidates else None,
+            )
+    return sorted(merged_mapped.values(), key=lambda col: col.source_index)
+
+
+def _build_merged_column_scores(
+    *,
+    tables: list[TableResult],
+    merged_df: pl.DataFrame,
+) -> dict[int, dict[str, float]]:
+    merged_scores_by_name: dict[str, dict[str, float]] = {}
+    for table_result in tables:
+        for source_index, scores in table_result.column_scores.items():
+            if not (0 <= source_index < len(table_result.table.columns)):
+                continue
+            column_name = table_result.table.columns[source_index]
+            merged_scores = merged_scores_by_name.setdefault(column_name, {})
+            for field_name, score in scores.items():
+                current = merged_scores.get(field_name)
+                merged_scores[field_name] = score if current is None else max(current, score)
+
+    merged_scores: dict[int, dict[str, float]] = {}
+    for index, column_name in enumerate(merged_df.columns):
+        scores = merged_scores_by_name.get(column_name)
+        if scores:
+            merged_scores[index] = dict(scores)
+    return merged_scores
+
+
+def _build_merged_table_result(tables: list[TableResult], merged_df: pl.DataFrame) -> TableResult:
+    if not tables:
+        raise PipelineError("Failed to merge in-sheet tables: no tables provided")
+
+    sheet_name = tables[0].sheet_name
+    sheet_index = tables[0].sheet_index
+    if any(table.sheet_name != sheet_name for table in tables):
+        raise PipelineError("Failed to merge in-sheet tables: contributing tables span multiple sheets")
+    if any(table.sheet_index != sheet_index for table in tables):
+        raise PipelineError("Failed to merge in-sheet tables: contributing tables span multiple sheet indexes")
+
+    headers_by_name = _collect_source_headers_by_column_name(tables)
+    source_columns = _build_merged_source_columns(merged_df=merged_df, headers_by_name=headers_by_name)
+    mapped_columns = _build_merged_mapped_columns(tables=tables, merged_df=merged_df)
+    mapped_names = {column.field_name for column in mapped_columns}
+    unmapped_columns = [column for column in source_columns if merged_df.columns[column.index] not in mapped_names]
+    duplicate_unmapped_indices = {
+        source_column.index
+        for source_column in unmapped_columns
+        if source_column.index < len(merged_df.columns) and merged_df.columns[source_column.index] in mapped_names
+    }
+
+    return TableResult(
+        sheet_name=sheet_name,
+        table=merged_df,
+        source_region=_merge_source_regions(tables),
+        source_columns=source_columns,
+        table_index=0,
+        sheet_index=sheet_index,
+        mapped_columns=mapped_columns,
+        unmapped_columns=unmapped_columns,
+        column_scores=_build_merged_column_scores(tables=tables, merged_df=merged_df),
+        duplicate_unmapped_indices=duplicate_unmapped_indices,
+        row_count=merged_df.height,
+    )
+
+
 def _merge_source_regions(tables: list[TableResult]) -> TableRegion:
     regions = [table.source_region for table in tables if isinstance(table.source_region, TableRegion)]
     if not regions:
@@ -195,25 +400,21 @@ def _merge_tables_in_sheet(tables: list[TableResult]) -> list[TableResult]:
     if len(tables) <= 1:
         return tables
 
-    merged = pl.concat([table.table for table in tables], how="diagonal")
-    ordered_columns = _ordered_column_union(tables)
-    if ordered_columns:
-        merged = merged.select(ordered_columns)
+    column_order = _resolve_merged_column_order(tables)
+    dtype_by_column = {column_name: _resolve_merged_column_dtype(column_name, tables) for column_name in column_order}
 
-    template = tables[0]
-    merged_result = TableResult(
-        sheet_name=template.sheet_name,
-        table=merged,
-        source_region=_merge_source_regions(tables),
-        source_columns=template.source_columns,
-        table_index=0,
-        sheet_index=template.sheet_index,
-        mapped_columns=template.mapped_columns,
-        unmapped_columns=template.unmapped_columns,
-        column_scores=template.column_scores,
-        duplicate_unmapped_indices=set(template.duplicate_unmapped_indices),
-        row_count=merged.height,
-    )
+    try:
+        aligned_tables = [
+            _align_table_for_merge(table_result=table_result, column_order=column_order, dtype_by_column=dtype_by_column)
+            for table_result in tables
+        ]
+        merged = pl.concat(aligned_tables, how="vertical") if aligned_tables else pl.DataFrame()
+    except PipelineError:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive normalization around Polars internals
+        raise PipelineError(f"Failed to merge in-sheet tables: {exc}") from exc
+
+    merged_result = _build_merged_table_result(tables, merged)
     return [merged_result]
 
 

--- a/src/ade_engine/application/pipeline/pipeline.py
+++ b/src/ade_engine/application/pipeline/pipeline.py
@@ -192,6 +192,50 @@ def _is_float_dtype(dtype: pl.DataType) -> bool:
     return dtype in {pl.Float32, pl.Float64}
 
 
+def _integer_dtype_width(dtype: pl.DataType) -> int:
+    widths = {
+        pl.Int8: 8,
+        pl.Int16: 16,
+        pl.Int32: 32,
+        pl.Int64: 64,
+        pl.UInt8: 8,
+        pl.UInt16: 16,
+        pl.UInt32: 32,
+        pl.UInt64: 64,
+    }
+    return widths[dtype]
+
+
+def _is_signed_integer_dtype(dtype: pl.DataType) -> bool:
+    return dtype in {pl.Int8, pl.Int16, pl.Int32, pl.Int64}
+
+
+def _resolve_integer_supertype(dtypes: set[pl.DataType]) -> pl.DataType:
+    if all(_is_signed_integer_dtype(dtype) for dtype in dtypes):
+        widest = max(_integer_dtype_width(dtype) for dtype in dtypes)
+        return {8: pl.Int8, 16: pl.Int16, 32: pl.Int32, 64: pl.Int64}[widest]
+
+    if all(not _is_signed_integer_dtype(dtype) for dtype in dtypes):
+        widest = max(_integer_dtype_width(dtype) for dtype in dtypes)
+        return {8: pl.UInt8, 16: pl.UInt16, 32: pl.UInt32, 64: pl.UInt64}[widest]
+
+    widest_unsigned = max(_integer_dtype_width(dtype) for dtype in dtypes if not _is_signed_integer_dtype(dtype))
+    widest_signed = max(_integer_dtype_width(dtype) for dtype in dtypes if _is_signed_integer_dtype(dtype))
+
+    signed_candidates = (
+        (8, pl.Int8),
+        (16, pl.Int16),
+        (32, pl.Int32),
+        (64, pl.Int64),
+    )
+    required_signed_width = max(widest_signed, min(64, widest_unsigned * 2))
+    for width, dtype in signed_candidates:
+        if width >= required_signed_width:
+            return dtype
+
+    raise PipelineError("Failed to merge in-sheet tables: no safe integer supertype for signed/unsigned mix")
+
+
 def _dtype_sort_key(dtype: pl.DataType) -> str:
     return repr(dtype)
 
@@ -216,6 +260,15 @@ def _resolve_merged_column_dtype(column_name: str, tables: list[TableResult]) ->
     unique_concrete = {dtype for dtype in concrete}
     if len(unique_concrete) == 1:
         return next(iter(unique_concrete))
+
+    if all(_is_integer_dtype(dtype) for dtype in unique_concrete):
+        try:
+            return _resolve_integer_supertype(unique_concrete)
+        except PipelineError as exc:
+            dtype_list = ", ".join(sorted({_dtype_sort_key(dtype) for dtype in observed}))
+            raise PipelineError(
+                f"Failed to merge in-sheet tables: incompatible dtypes for column '{column_name}' ({dtype_list})"
+            ) from exc
 
     if all(_is_integer_dtype(dtype) or _is_float_dtype(dtype) for dtype in unique_concrete):
         return pl.Float64
@@ -354,10 +407,14 @@ def _build_merged_table_result(tables: list[TableResult], merged_df: pl.DataFram
     mapped_columns = _build_merged_mapped_columns(tables=tables, merged_df=merged_df)
     mapped_names = {column.field_name for column in mapped_columns}
     unmapped_columns = [column for column in source_columns if merged_df.columns[column.index] not in mapped_names]
+    duplicate_unmapped_names: set[str] = set()
+    for table_result in tables:
+        for source_index in table_result.duplicate_unmapped_indices:
+            if 0 <= source_index < len(table_result.table.columns):
+                duplicate_unmapped_names.add(table_result.table.columns[source_index])
+
     duplicate_unmapped_indices = {
-        source_column.index
-        for source_column in unmapped_columns
-        if source_column.index < len(merged_df.columns) and merged_df.columns[source_column.index] in mapped_names
+        index for index, column_name in enumerate(merged_df.columns) if column_name in duplicate_unmapped_names
     }
 
     return TableResult(

--- a/src/ade_engine/infrastructure/io/workbook.py
+++ b/src/ade_engine/infrastructure/io/workbook.py
@@ -17,24 +17,12 @@ from openpyxl import Workbook
 from ade_engine.models.errors import InputError
 
 _XLS_METADATA_ATTR = "_ade_xls_metadata"
-
-
-@dataclass(frozen=True)
-class _XlsSheetInfo:
-    original_name: str
-    converted_name: str
-    source_index: int
-    visibility: int
-    is_active: bool
-    is_selected: bool
+_XLS_ORIGINAL_NAME_ATTR = "_ade_xls_original_name"
 
 
 @dataclass(frozen=True)
 class _XlsWorkbookMetadata:
-    sheets: tuple[_XlsSheetInfo, ...]
-    source_to_converted: dict[str, str]
-    active_source_name: str | None
-    active_converted_name: str | None
+    is_converted_xls: bool = True
 
 
 def load_source_workbook(path: Path) -> Workbook:
@@ -99,11 +87,10 @@ def _convert_xlrd_book_to_openpyxl(book: Any) -> Workbook:
     visible_sheet_index: int | None = None
     selected_sheet_index: int | None = None
     active_sheet_index: int | None = None
-    sheet_infos: list[_XlsSheetInfo] = []
-
     for sheet_index in range(book.nsheets):
         sheet = book.sheet_by_index(sheet_index)
         ws = workbook.create_sheet(title=sheet.name)
+        setattr(ws, _XLS_ORIGINAL_NAME_ATTR, str(sheet.name))
 
         visibility = _get_xls_sheet_visibility(book, sheet, sheet_index)
         ws.sheet_state = _map_sheet_visibility(visibility)
@@ -116,17 +103,6 @@ def _convert_xlrd_book_to_openpyxl(book: Any) -> Workbook:
             active_sheet_index = sheet_index
         if selected_sheet_index is None and is_visible and is_selected:
             selected_sheet_index = sheet_index
-
-        sheet_infos.append(
-            _XlsSheetInfo(
-                original_name=str(sheet.name),
-                converted_name=str(ws.title),
-                source_index=sheet_index,
-                visibility=visibility,
-                is_active=is_active,
-                is_selected=is_selected,
-            )
-        )
 
         for row_index in range(sheet.nrows):
             row_values = [_convert_xls_cell_value(book, cell) for cell in _iter_xls_row_cells(sheet, row_index)]
@@ -155,7 +131,7 @@ def _convert_xlrd_book_to_openpyxl(book: Any) -> Workbook:
         resolved_active_index = 0
 
     workbook.active = resolved_active_index
-    _set_xls_workbook_metadata(workbook, sheet_infos, resolved_active_index)
+    _set_xls_workbook_metadata(workbook)
     return workbook
 
 
@@ -198,23 +174,11 @@ def _get_xls_sheet_visibility(book: Any, sheet: Any, sheet_index: int) -> int:
     return 0
 
 
-def _set_xls_workbook_metadata(workbook: Workbook, sheet_infos: list[_XlsSheetInfo], active_sheet_index: int) -> None:
-    active_source_name: str | None = None
-    active_converted_name: str | None = None
-    if 0 <= active_sheet_index < len(sheet_infos):
-        active_info = sheet_infos[active_sheet_index]
-        active_source_name = active_info.original_name
-        active_converted_name = active_info.converted_name
-
+def _set_xls_workbook_metadata(workbook: Workbook) -> None:
     setattr(
         workbook,
         _XLS_METADATA_ATTR,
-        _XlsWorkbookMetadata(
-            sheets=tuple(sheet_infos),
-            source_to_converted={info.original_name: info.converted_name for info in sheet_infos},
-            active_source_name=active_source_name,
-            active_converted_name=active_converted_name,
-        ),
+        _XlsWorkbookMetadata(),
     )
 
 
@@ -287,7 +251,7 @@ def resolve_sheet_names(
 
     xls_metadata = _get_xls_workbook_metadata(workbook)
     if xls_metadata is not None:
-        return _resolve_xls_sheet_names(xls_metadata, requested, active_only=active_only)
+        return _resolve_xls_sheet_names(workbook, requested, active_only=active_only)
 
     visible = [ws.title for ws in workbook.worksheets if getattr(ws, "sheet_state", "visible") == "visible"]
     if active_only:
@@ -315,37 +279,42 @@ def resolve_sheet_names(
 
 
 def _resolve_xls_sheet_names(
-    metadata: _XlsWorkbookMetadata,
+    workbook: Workbook,
     requested: list[str] | None,
     *,
     active_only: bool,
 ) -> list[str]:
-    visible_infos = [info for info in metadata.sheets if _map_sheet_visibility(info.visibility) == "visible"]
-    visible_original = [info.original_name for info in visible_infos]
-    visible_converted = [info.converted_name for info in visible_infos]
-
+    visible_sheets = [ws for ws in workbook.worksheets if getattr(ws, "sheet_state", "visible") == "visible"]
+    visible_titles = [ws.title for ws in visible_sheets]
     if active_only:
-        if not visible_infos:
+        if not visible_sheets:
             raise InputError("No visible worksheets available")
-        active_name = metadata.active_source_name
+        active = workbook.active
+        active_name = getattr(active, "title", None)
         if not active_name:
             raise InputError("Active worksheet is not available")
-        if active_name not in visible_original:
+        if active_name not in visible_titles:
             raise InputError(f"Active worksheet is hidden: {active_name}")
-        return [metadata.source_to_converted[active_name]]
+        return [active_name]
 
     if not requested:
-        return visible_converted
+        return visible_titles
 
     cleaned = [name.strip() for name in requested if isinstance(name, str) and name.strip()]
     unique_requested = list(dict.fromkeys(cleaned))
 
-    missing = [name for name in unique_requested if name not in visible_original]
+    visible_by_requested_name: dict[str, str] = {}
+    for ws in visible_sheets:
+        visible_by_requested_name[ws.title] = ws.title
+        visible_by_requested_name[str(getattr(ws, _XLS_ORIGINAL_NAME_ATTR, ws.title))] = ws.title
+
+    missing = [name for name in unique_requested if name not in visible_by_requested_name]
     if missing:
         raise InputError(f"Worksheet(s) not found: {', '.join(missing)}")
 
-    order_index = {info.original_name: idx for idx, info in enumerate(visible_infos)}
-    return [metadata.source_to_converted[name] for name in sorted(unique_requested, key=lambda n: order_index[n])]
+    order_index = {ws.title: idx for idx, ws in enumerate(visible_sheets)}
+    resolved = [visible_by_requested_name[name] for name in unique_requested]
+    return sorted(resolved, key=lambda n: order_index[n])
 
 
 __all__ = [

--- a/src/ade_engine/infrastructure/io/workbook.py
+++ b/src/ade_engine/infrastructure/io/workbook.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import csv
 import math
 from contextlib import contextmanager, suppress
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -14,6 +15,26 @@ import openpyxl
 from openpyxl import Workbook
 
 from ade_engine.models.errors import InputError
+
+_XLS_METADATA_ATTR = "_ade_xls_metadata"
+
+
+@dataclass(frozen=True)
+class _XlsSheetInfo:
+    original_name: str
+    converted_name: str
+    source_index: int
+    visibility: int
+    is_active: bool
+    is_selected: bool
+
+
+@dataclass(frozen=True)
+class _XlsWorkbookMetadata:
+    sheets: tuple[_XlsSheetInfo, ...]
+    source_to_converted: dict[str, str]
+    active_source_name: str | None
+    active_converted_name: str | None
 
 
 def load_source_workbook(path: Path) -> Workbook:
@@ -76,16 +97,36 @@ def _convert_xlrd_book_to_openpyxl(book: Any) -> Workbook:
         workbook.remove(workbook.worksheets[0])
 
     visible_sheet_index: int | None = None
-    visibility_by_sheet = list(getattr(book, "sheet_visibility", []))
+    selected_sheet_index: int | None = None
+    active_sheet_index: int | None = None
+    sheet_infos: list[_XlsSheetInfo] = []
 
     for sheet_index in range(book.nsheets):
         sheet = book.sheet_by_index(sheet_index)
         ws = workbook.create_sheet(title=sheet.name)
 
-        visibility = visibility_by_sheet[sheet_index] if sheet_index < len(visibility_by_sheet) else 0
+        visibility = _get_xls_sheet_visibility(book, sheet, sheet_index)
         ws.sheet_state = _map_sheet_visibility(visibility)
-        if visible_sheet_index is None and ws.sheet_state == "visible":
+        is_visible = ws.sheet_state == "visible"
+        is_active = bool(getattr(sheet, "sheet_visible", False))
+        is_selected = bool(getattr(sheet, "sheet_selected", False))
+        if visible_sheet_index is None and is_visible:
             visible_sheet_index = sheet_index
+        if active_sheet_index is None and is_visible and is_active:
+            active_sheet_index = sheet_index
+        if selected_sheet_index is None and is_visible and is_selected:
+            selected_sheet_index = sheet_index
+
+        sheet_infos.append(
+            _XlsSheetInfo(
+                original_name=str(sheet.name),
+                converted_name=str(ws.title),
+                source_index=sheet_index,
+                visibility=visibility,
+                is_active=is_active,
+                is_selected=is_selected,
+            )
+        )
 
         for row_index in range(sheet.nrows):
             row_values = [_convert_xls_cell_value(book, cell) for cell in _iter_xls_row_cells(sheet, row_index)]
@@ -105,7 +146,16 @@ def _convert_xlrd_book_to_openpyxl(book: Any) -> Workbook:
     if not workbook.worksheets:
         raise InputError("Workbook contains no worksheets")
 
-    workbook.active = visible_sheet_index if visible_sheet_index is not None else 0
+    resolved_active_index = active_sheet_index
+    if resolved_active_index is None:
+        resolved_active_index = selected_sheet_index
+    if resolved_active_index is None:
+        resolved_active_index = visible_sheet_index
+    if resolved_active_index is None:
+        resolved_active_index = 0
+
+    workbook.active = resolved_active_index
+    _set_xls_workbook_metadata(workbook, sheet_infos, resolved_active_index)
     return workbook
 
 
@@ -131,6 +181,48 @@ def _iter_xls_row_cells(sheet: Any, row_index: int) -> list[Any]:
         ]
 
     return [sheet.cell(row_index, col_index) for col_index in range(sheet.ncols)]
+
+
+def _get_xls_sheet_visibility(book: Any, sheet: Any, sheet_index: int) -> int:
+    visibility = getattr(sheet, "visibility", None)
+    if isinstance(visibility, int):
+        return visibility
+
+    visibility_by_sheet = getattr(book, "_sheet_visibility", None)
+    if visibility_by_sheet is None:
+        visibility_by_sheet = getattr(book, "sheet_visibility", None)
+    if isinstance(visibility_by_sheet, (list, tuple)) and sheet_index < len(visibility_by_sheet):
+        raw_visibility = visibility_by_sheet[sheet_index]
+        if isinstance(raw_visibility, int):
+            return raw_visibility
+    return 0
+
+
+def _set_xls_workbook_metadata(workbook: Workbook, sheet_infos: list[_XlsSheetInfo], active_sheet_index: int) -> None:
+    active_source_name: str | None = None
+    active_converted_name: str | None = None
+    if 0 <= active_sheet_index < len(sheet_infos):
+        active_info = sheet_infos[active_sheet_index]
+        active_source_name = active_info.original_name
+        active_converted_name = active_info.converted_name
+
+    setattr(
+        workbook,
+        _XLS_METADATA_ATTR,
+        _XlsWorkbookMetadata(
+            sheets=tuple(sheet_infos),
+            source_to_converted={info.original_name: info.converted_name for info in sheet_infos},
+            active_source_name=active_source_name,
+            active_converted_name=active_converted_name,
+        ),
+    )
+
+
+def _get_xls_workbook_metadata(workbook: Workbook) -> _XlsWorkbookMetadata | None:
+    metadata = getattr(workbook, _XLS_METADATA_ATTR, None)
+    if isinstance(metadata, _XlsWorkbookMetadata):
+        return metadata
+    return None
 
 
 def _convert_xls_cell_value(book: Any, cell: Any) -> Any:
@@ -193,6 +285,10 @@ def resolve_sheet_names(
 ) -> list[str]:
     """Determine which sheets to process, preserving source order."""
 
+    xls_metadata = _get_xls_workbook_metadata(workbook)
+    if xls_metadata is not None:
+        return _resolve_xls_sheet_names(xls_metadata, requested, active_only=active_only)
+
     visible = [ws.title for ws in workbook.worksheets if getattr(ws, "sheet_state", "visible") == "visible"]
     if active_only:
         if not visible:
@@ -216,6 +312,40 @@ def resolve_sheet_names(
 
     order_index = {name: idx for idx, name in enumerate(visible)}
     return sorted(unique_requested, key=lambda n: order_index[n])
+
+
+def _resolve_xls_sheet_names(
+    metadata: _XlsWorkbookMetadata,
+    requested: list[str] | None,
+    *,
+    active_only: bool,
+) -> list[str]:
+    visible_infos = [info for info in metadata.sheets if _map_sheet_visibility(info.visibility) == "visible"]
+    visible_original = [info.original_name for info in visible_infos]
+    visible_converted = [info.converted_name for info in visible_infos]
+
+    if active_only:
+        if not visible_infos:
+            raise InputError("No visible worksheets available")
+        active_name = metadata.active_source_name
+        if not active_name:
+            raise InputError("Active worksheet is not available")
+        if active_name not in visible_original:
+            raise InputError(f"Active worksheet is hidden: {active_name}")
+        return [metadata.source_to_converted[active_name]]
+
+    if not requested:
+        return visible_converted
+
+    cleaned = [name.strip() for name in requested if isinstance(name, str) and name.strip()]
+    unique_requested = list(dict.fromkeys(cleaned))
+
+    missing = [name for name in unique_requested if name not in visible_original]
+    if missing:
+        raise InputError(f"Worksheet(s) not found: {', '.join(missing)}")
+
+    order_index = {info.original_name: idx for idx, info in enumerate(visible_infos)}
+    return [metadata.source_to_converted[name] for name in sorted(unique_requested, key=lambda n: order_index[n])]
 
 
 __all__ = [

--- a/tests/integration/test_integration_xls_e2e.py
+++ b/tests/integration/test_integration_xls_e2e.py
@@ -90,6 +90,30 @@ def _write_xls_workbook(path: Path) -> None:
     workbook.save(str(path))
 
 
+def _write_multi_sheet_xls_workbook(path: Path) -> None:
+    xlwt = pytest.importorskip("xlwt")
+
+    workbook = xlwt.Workbook()
+
+    primary = workbook.add_sheet("Summary")
+    primary.write(0, 0, "Email")
+    primary.write(0, 1, "Name")
+    primary.write(0, 2, "Notes")
+    primary.write(1, 0, "USER@Example.com")
+    primary.write(1, 1, "Alice")
+    primary.write(1, 2, "main-note")
+
+    secondary = workbook.add_sheet("Executive")
+    secondary.write(0, 0, "Email")
+    secondary.write(0, 1, "Name")
+    secondary.write(0, 2, "Notes")
+    secondary.write(1, 0, "OTHER@Example.com")
+    secondary.write(1, 1, "Bob")
+    secondary.write(1, 2, "secondary-note")
+
+    workbook.save(str(path))
+
+
 def test_end_to_end_pipeline_for_xls(tmp_path: Path):
     config_root = tmp_path / "cfg"
     config_root.mkdir()
@@ -149,4 +173,63 @@ def test_corrupt_xls_fails_with_input_error(tmp_path: Path):
     assert result.status == RunStatus.FAILED
     assert result.error is not None
     assert result.error.code == RunErrorCode.INPUT_ERROR
+
+
+def test_end_to_end_pipeline_for_xls_processes_requested_sheet_names_from_source_workbook(tmp_path: Path):
+    config_root = tmp_path / "cfg"
+    config_root.mkdir()
+    _write_config_package(config_root)
+
+    source = tmp_path / "multi_input.xls"
+    _write_multi_sheet_xls_workbook(source)
+
+    engine = Engine(settings=Settings())
+    result = engine.run(
+        RunRequest(
+            config_package=config_root,
+            input_file=source,
+            input_sheets=["Executive"],
+            output_dir=tmp_path / "out",
+            logs_dir=tmp_path / "logs",
+        )
+    )
+
+    assert result.status == RunStatus.SUCCEEDED
+    assert result.output_path is not None
+
+    wb = openpyxl.load_workbook(result.output_path)
+    assert wb.sheetnames == ["Executive"]
+    rows = list(wb.active.iter_rows(min_row=2, values_only=True))
+    assert rows == [("other@example.com", "Bob", "secondary-note")]
+    wb.close()
+
+
+def test_end_to_end_pipeline_for_xls_processes_all_visible_sheets_in_source_order(tmp_path: Path):
+    config_root = tmp_path / "cfg"
+    config_root.mkdir()
+    _write_config_package(config_root)
+
+    source = tmp_path / "multi_input.xls"
+    _write_multi_sheet_xls_workbook(source)
+
+    engine = Engine(settings=Settings())
+    result = engine.run(
+        RunRequest(
+            config_package=config_root,
+            input_file=source,
+            output_dir=tmp_path / "out",
+            logs_dir=tmp_path / "logs",
+        )
+    )
+
+    assert result.status == RunStatus.SUCCEEDED
+    assert result.output_path is not None
+
+    wb = openpyxl.load_workbook(result.output_path)
+    assert wb.sheetnames == ["Summary", "Executive"]
+    first_rows = list(wb["Summary"].iter_rows(min_row=2, values_only=True))
+    second_rows = list(wb["Executive"].iter_rows(min_row=2, values_only=True))
+    assert first_rows == [("user@example.com", "Alice", "main-note")]
+    assert second_rows == [("other@example.com", "Bob", "secondary-note")]
+    wb.close()
 

--- a/tests/unit/test_pipeline_multi_table.py
+++ b/tests/unit/test_pipeline_multi_table.py
@@ -4,12 +4,13 @@ from openpyxl import Workbook
 import polars as pl
 import pytest
 
-from ade_engine.application.pipeline.pipeline import Pipeline
+from ade_engine.application.pipeline.pipeline import Pipeline, _merge_tables_in_sheet
 from ade_engine.extensions.registry import Registry
 from ade_engine.infrastructure.observability.logger import NullLogger
 from ade_engine.infrastructure.settings import Settings
 from ade_engine.models.errors import PipelineError
 from ade_engine.models.extension_contexts import FieldDef, RowKind
+from ade_engine.models.table import SourceColumn, TableRegion, TableResult
 
 
 def test_process_sheet_renders_multiple_tables_with_blank_row():
@@ -520,3 +521,58 @@ def test_on_table_written_receives_merged_metadata_for_merged_tables():
     assert source_headers["Email"] == mapped_indices["email"]
     assert source_headers["Name"] == mapped_indices["name"]
     assert state["source_region"] == "A1:A5"
+
+
+def test_merge_tables_in_sheet_preserves_integer_supertype_without_float_widening():
+    table_a = TableResult(
+        sheet_name="Sheet1",
+        table=pl.DataFrame({"member_id": pl.Series("member_id", [1], dtype=pl.Int32)}),
+        source_region=TableRegion(min_row=1, min_col=1, max_row=2, max_col=1),
+        source_columns=[SourceColumn(index=0, header="Member ID", values=[1])],
+        table_index=0,
+        sheet_index=0,
+        row_count=1,
+    )
+    table_b = TableResult(
+        sheet_name="Sheet1",
+        table=pl.DataFrame({"member_id": pl.Series("member_id", [2], dtype=pl.Int64)}),
+        source_region=TableRegion(min_row=4, min_col=1, max_row=5, max_col=1),
+        source_columns=[SourceColumn(index=0, header="Member ID", values=[2])],
+        table_index=1,
+        sheet_index=0,
+        row_count=1,
+    )
+
+    merged = _merge_tables_in_sheet([table_a, table_b])[0]
+
+    assert merged.table.schema["member_id"] == pl.Int64
+    assert merged.table.get_column("member_id").to_list() == [1, 2]
+
+
+def test_merge_tables_in_sheet_preserves_duplicate_unmapped_indices():
+    table_a = TableResult(
+        sheet_name="Sheet1",
+        table=pl.DataFrame({"Notes": ["alpha"]}),
+        source_region=TableRegion(min_row=1, min_col=1, max_row=2, max_col=1),
+        source_columns=[SourceColumn(index=0, header="Notes", values=["alpha"])],
+        table_index=0,
+        sheet_index=0,
+        unmapped_columns=[SourceColumn(index=0, header="Notes", values=["alpha"])],
+        duplicate_unmapped_indices={0},
+        row_count=1,
+    )
+    table_b = TableResult(
+        sheet_name="Sheet1",
+        table=pl.DataFrame({"Notes": ["beta"]}),
+        source_region=TableRegion(min_row=4, min_col=1, max_row=5, max_col=1),
+        source_columns=[SourceColumn(index=0, header="Notes", values=["beta"])],
+        table_index=1,
+        sheet_index=0,
+        unmapped_columns=[SourceColumn(index=0, header="Notes", values=["beta"])],
+        duplicate_unmapped_indices={0},
+        row_count=1,
+    )
+
+    merged = _merge_tables_in_sheet([table_a, table_b])[0]
+
+    assert merged.duplicate_unmapped_indices == {0}

--- a/tests/unit/test_pipeline_multi_table.py
+++ b/tests/unit/test_pipeline_multi_table.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from openpyxl import Workbook
+import polars as pl
+import pytest
 
 from ade_engine.application.pipeline.pipeline import Pipeline
 from ade_engine.extensions.registry import Registry
 from ade_engine.infrastructure.observability.logger import NullLogger
 from ade_engine.infrastructure.settings import Settings
+from ade_engine.models.errors import PipelineError
 from ade_engine.models.extension_contexts import FieldDef, RowKind
 
 
@@ -228,3 +231,292 @@ def test_on_table_written_receives_written_table_after_output_policies():
 
     headers = list(output_ws.iter_rows(min_row=1, max_row=1, max_col=2, values_only=True))[0]
     assert headers == ("email", "name")
+
+
+def test_merge_tables_in_sheet_merges_metadata_from_all_tables():
+    registry = Registry()
+    logger = NullLogger()
+
+    registry.register_field(FieldDef(name="email"))
+    registry.register_field(FieldDef(name="name"))
+
+    def detector(*, row_index, **_):
+        if row_index in (1, 4):
+            return {RowKind.HEADER.value: 1.0}
+        if row_index in (2, 5):
+            return {RowKind.DATA.value: 1.0}
+        return {}
+
+    def detect_email(*, column_header_original, **_):
+        return {"email": 1.0} if column_header_original.strip().lower() == "email" else {}
+
+    def detect_name(*, column_header_original, **_):
+        return {"name": 1.0} if column_header_original.strip().lower() == "name" else {}
+
+    registry.register_row_detector(detector, row_kind=RowKind.UNKNOWN.value, priority=0)
+    registry.register_column_detector(detect_email, field="email", priority=0)
+    registry.register_column_detector(detect_name, field="name", priority=0)
+    registry.finalize()
+
+    pipeline = Pipeline(
+        registry=registry,
+        settings=Settings(merge_tables_in_sheet=True, write_diagnostics_columns=False),
+        logger=logger,
+    )
+
+    source_wb = Workbook()
+    source_ws = source_wb.active
+    source_ws.title = "Sheet1"
+    source_ws.append(["Email"])
+    source_ws.append(["a@example.com"])
+    source_ws.append([])
+    source_ws.append(["Name"])
+    source_ws.append(["Alice"])
+
+    output_wb = Workbook()
+    output_wb.remove(output_wb.active)
+    output_ws = output_wb.create_sheet(title="Sheet1")
+
+    tables = pipeline.process_sheet(
+        sheet=source_ws,
+        output_sheet=output_ws,
+        state={},
+        metadata={"input_file": "input.xlsx", "sheet_index": 0},
+        input_file_name="input.xlsx",
+    )
+
+    assert len(tables) == 1
+    table = tables[0]
+    assert "email" in table.table.columns
+    assert "name" in table.table.columns
+    assert table.source_region.a1 == "A1:A5"
+    assert {column.field_name for column in table.mapped_columns} == {"email", "name"}
+    mapped_indices = {column.field_name: column.source_index for column in table.mapped_columns}
+    assert table.table.columns[mapped_indices["email"]] == "email"
+    assert table.table.columns[mapped_indices["name"]] == "name"
+    source_headers = {column.header: column.index for column in table.source_columns if column.header not in (None, "")}
+    assert source_headers["Email"] == mapped_indices["email"]
+    assert source_headers["Name"] == mapped_indices["name"]
+    score_columns = {table.table.columns[index]: scores for index, scores in table.column_scores.items()}
+    assert score_columns["email"] == {"email": 1.0}
+    assert score_columns["name"] == {"name": 1.0}
+
+    emitted = list(output_ws.iter_rows(min_row=1, max_row=4, max_col=2, values_only=True))
+    assert emitted == [
+        ("email", "name"),
+        ("a@example.com", None),
+        (None, None),
+        (None, "Alice"),
+    ]
+
+
+def test_merge_tables_in_sheet_coerces_null_and_string_columns():
+    registry = Registry()
+    logger = NullLogger()
+
+    def detector(*, row_index, **_):
+        if row_index in (1, 4):
+            return {RowKind.HEADER.value: 1.0}
+        if row_index in (2, 5):
+            return {RowKind.DATA.value: 1.0}
+        return {}
+
+    registry.register_row_detector(detector, row_kind=RowKind.UNKNOWN.value, priority=0)
+    registry.finalize()
+
+    pipeline = Pipeline(
+        registry=registry,
+        settings=Settings(merge_tables_in_sheet=True, write_diagnostics_columns=False),
+        logger=logger,
+    )
+
+    source_wb = Workbook()
+    source_ws = source_wb.active
+    source_ws.title = "Sheet1"
+    source_ws.append(["SIN", "Comments"])
+    source_ws.append(["123456789", None])
+    source_ws.append([])
+    source_ws.append(["SIN", "Comments"])
+    source_ws.append(["987654321", "NQ"])
+
+    output_wb = Workbook()
+    output_wb.remove(output_wb.active)
+    output_ws = output_wb.create_sheet(title="Sheet1")
+
+    tables = pipeline.process_sheet(
+        sheet=source_ws,
+        output_sheet=output_ws,
+        state={},
+        metadata={"input_file": "apr.xlsx", "sheet_index": 0},
+        input_file_name="apr.xlsx",
+    )
+
+    assert len(tables) == 1
+    assert tables[0].table.columns[0:2] == ["SIN", "Comments"]
+    assert tables[0].table.schema["Comments"] == pl.String
+
+    emitted = list(output_ws.iter_rows(min_row=1, max_row=4, max_col=2, values_only=True))
+    assert emitted == [
+        ("SIN", "Comments"),
+        ("123456789", None),
+        (None, None),
+        ("987654321", "NQ"),
+    ]
+
+
+def test_merge_tables_in_sheet_widens_numeric_types():
+    registry = Registry()
+    logger = NullLogger()
+
+    def detector(*, row_index, **_):
+        if row_index in (1, 4):
+            return {RowKind.HEADER.value: 1.0}
+        if row_index in (2, 5):
+            return {RowKind.DATA.value: 1.0}
+        return {}
+
+    registry.register_row_detector(detector, row_kind=RowKind.UNKNOWN.value, priority=0)
+    registry.finalize()
+
+    pipeline = Pipeline(
+        registry=registry,
+        settings=Settings(merge_tables_in_sheet=True, write_diagnostics_columns=False),
+        logger=logger,
+    )
+
+    source_wb = Workbook()
+    source_ws = source_wb.active
+    source_ws.title = "Sheet1"
+    source_ws.append(["Amount"])
+    source_ws.append([10])
+    source_ws.append([])
+    source_ws.append(["Amount"])
+    source_ws.append([2.5])
+
+    output_wb = Workbook()
+    output_wb.remove(output_wb.active)
+    output_ws = output_wb.create_sheet(title="Sheet1")
+
+    tables = pipeline.process_sheet(
+        sheet=source_ws,
+        output_sheet=output_ws,
+        state={},
+        metadata={"input_file": "input.xlsx", "sheet_index": 0},
+        input_file_name="input.xlsx",
+    )
+
+    assert len(tables) == 1
+    assert tables[0].table.schema["Amount"] == pl.Float64
+    assert tables[0].table.get_column("Amount").to_list() == [10.0, None, 2.5]
+
+
+def test_merge_tables_in_sheet_raises_clear_error_for_incompatible_types():
+    registry = Registry()
+    logger = NullLogger()
+
+    def detector(*, row_index, **_):
+        if row_index in (1, 4):
+            return {RowKind.HEADER.value: 1.0}
+        if row_index in (2, 5):
+            return {RowKind.DATA.value: 1.0}
+        return {}
+
+    registry.register_row_detector(detector, row_kind=RowKind.UNKNOWN.value, priority=0)
+    registry.finalize()
+
+    pipeline = Pipeline(
+        registry=registry,
+        settings=Settings(merge_tables_in_sheet=True, write_diagnostics_columns=False),
+        logger=logger,
+    )
+
+    source_wb = Workbook()
+    source_ws = source_wb.active
+    source_ws.title = "Sheet1"
+    source_ws.append(["Mixed"])
+    source_ws.append([True])
+    source_ws.append([])
+    source_ws.append(["Mixed"])
+    source_ws.append(["text"])
+
+    output_wb = Workbook()
+    output_wb.remove(output_wb.active)
+    output_ws = output_wb.create_sheet(title="Sheet1")
+
+    with pytest.raises(PipelineError, match=r"incompatible dtypes for column 'Mixed'"):
+        pipeline.process_sheet(
+            sheet=source_ws,
+            output_sheet=output_ws,
+            state={},
+            metadata={"input_file": "input.xlsx", "sheet_index": 0},
+            input_file_name="input.xlsx",
+        )
+
+
+def test_on_table_written_receives_merged_metadata_for_merged_tables():
+    registry = Registry()
+    logger = NullLogger()
+
+    registry.register_field(FieldDef(name="email"))
+    registry.register_field(FieldDef(name="name"))
+
+    def detector(*, row_index, **_):
+        if row_index in (1, 4):
+            return {RowKind.HEADER.value: 1.0}
+        if row_index in (2, 5):
+            return {RowKind.DATA.value: 1.0}
+        return {}
+
+    def detect_email(*, column_header_original, **_):
+        return {"email": 1.0} if column_header_original.strip().lower() == "email" else {}
+
+    def detect_name(*, column_header_original, **_):
+        return {"name": 1.0} if column_header_original.strip().lower() == "name" else {}
+
+    def capture_written(*, write_table, table_result, state, **_):
+        state["written_columns"] = list(write_table.columns)
+        state["mapped_columns"] = [(column.field_name, column.source_index) for column in table_result.mapped_columns]
+        state["source_columns"] = [(column.header, column.index) for column in table_result.source_columns]
+        state["source_region"] = table_result.source_region.a1
+
+    registry.register_row_detector(detector, row_kind=RowKind.UNKNOWN.value, priority=0)
+    registry.register_column_detector(detect_email, field="email", priority=0)
+    registry.register_column_detector(detect_name, field="name", priority=0)
+    registry.register_hook(capture_written, hook="on_table_written", priority=0)
+    registry.finalize()
+
+    pipeline = Pipeline(
+        registry=registry,
+        settings=Settings(merge_tables_in_sheet=True, write_diagnostics_columns=False),
+        logger=logger,
+    )
+
+    source_wb = Workbook()
+    source_ws = source_wb.active
+    source_ws.title = "Sheet1"
+    source_ws.append(["Email"])
+    source_ws.append(["a@example.com"])
+    source_ws.append([])
+    source_ws.append(["Name"])
+    source_ws.append(["Alice"])
+
+    output_wb = Workbook()
+    output_wb.remove(output_wb.active)
+    output_ws = output_wb.create_sheet(title="Sheet1")
+
+    state: dict = {}
+    pipeline.process_sheet(
+        sheet=source_ws,
+        output_sheet=output_ws,
+        state=state,
+        metadata={"input_file": "input.xlsx", "sheet_index": 0},
+        input_file_name="input.xlsx",
+    )
+
+    assert state["written_columns"] == ["email", "name"]
+    assert [field for field, _ in state["mapped_columns"]] == ["email", "name"]
+    source_headers = {header: index for header, index in state["source_columns"] if header not in (None, "")}
+    mapped_indices = dict(state["mapped_columns"])
+    assert source_headers["Email"] == mapped_indices["email"]
+    assert source_headers["Name"] == mapped_indices["name"]
+    assert state["source_region"] == "A1:A5"

--- a/tests/unit/test_workbook_io.py
+++ b/tests/unit/test_workbook_io.py
@@ -251,6 +251,43 @@ def test_resolve_sheet_names_for_xls_excludes_hidden_requested_sheets():
         resolve_sheet_names(workbook, requested=["Hidden"])
 
 
+def test_resolve_sheet_names_for_xls_respects_renames_after_conversion():
+    xlrd = pytest.importorskip("xlrd")
+
+    book = _FakeBook(
+        [
+            _FakeSheet("Original", rows=[[_FakeCell(xlrd.XL_CELL_TEXT, "a")]]),
+            _FakeSheet("Second", rows=[[_FakeCell(xlrd.XL_CELL_TEXT, "b")]]),
+        ]
+    )
+
+    workbook = _convert_xlrd_book_to_openpyxl(book)
+    workbook["Original"].title = "Renamed"
+
+    assert resolve_sheet_names(workbook, requested=["Original"]) == ["Renamed"]
+    assert resolve_sheet_names(workbook, requested=["Renamed"]) == ["Renamed"]
+
+
+def test_resolve_sheet_names_for_xls_respects_visibility_and_active_mutations_after_conversion():
+    xlrd = pytest.importorskip("xlrd")
+
+    book = _FakeBook(
+        [
+            _FakeSheet("First", rows=[[_FakeCell(xlrd.XL_CELL_TEXT, "a")]], sheet_visible=1),
+            _FakeSheet("Second", rows=[[_FakeCell(xlrd.XL_CELL_TEXT, "b")]]),
+        ]
+    )
+
+    workbook = _convert_xlrd_book_to_openpyxl(book)
+    workbook["First"].sheet_state = "hidden"
+    workbook.active = workbook["Second"]
+
+    assert resolve_sheet_names(workbook, requested=None) == ["Second"]
+    assert resolve_sheet_names(workbook, requested=None, active_only=True) == ["Second"]
+    with pytest.raises(InputError, match="Worksheet\\(s\\) not found: First"):
+        resolve_sheet_names(workbook, requested=["First"])
+
+
 def test_resolve_sheet_names_rejects_active_only_when_no_visible_sheets():
     workbook = Workbook()
     sheet = workbook.active

--- a/tests/unit/test_workbook_io.py
+++ b/tests/unit/test_workbook_io.py
@@ -25,12 +25,19 @@ class _FakeSheet:
         rows: list[list[_FakeCell]],
         *,
         merged_cells: list[tuple[int, int, int, int]] | None = None,
+        visibility: int | None = None,
+        sheet_visible: int = 0,
+        sheet_selected: int = 0,
     ) -> None:
         self.name = name
         self._rows = rows
         self.nrows = len(rows)
         self.ncols = max((len(row) for row in rows), default=0)
         self.merged_cells = merged_cells or []
+        if visibility is not None:
+            self.visibility = visibility
+        self.sheet_visible = sheet_visible
+        self.sheet_selected = sheet_selected
 
     def cell(self, row_index: int, col_index: int) -> _FakeCell:
         if row_index >= self.nrows or col_index >= len(self._rows[row_index]):
@@ -57,6 +64,7 @@ class _FakeBook:
         self.nsheets = len(sheets)
         self.datemode = datemode
         self.sheet_visibility = sheet_visibility or [0] * len(sheets)
+        self._sheet_visibility = self.sheet_visibility
 
     def sheet_by_index(self, index: int) -> _FakeSheet:
         return self._sheets[index]
@@ -98,8 +106,9 @@ def test_convert_xlrd_book_to_openpyxl_preserves_visibility_merges_and_cell_type
             ],
         ],
         merged_cells=[(0, 1, 0, 2)],
+        sheet_visible=1,
     )
-    hidden_sheet = _FakeSheet("Hidden", rows=[[_FakeCell(xlrd.XL_CELL_TEXT, "secret")]])
+    hidden_sheet = _FakeSheet("Hidden", rows=[[_FakeCell(xlrd.XL_CELL_TEXT, "secret")]], visibility=1)
     book = _FakeBook([visible_sheet, hidden_sheet], sheet_visibility=[0, 1])
 
     workbook = _convert_xlrd_book_to_openpyxl(book)
@@ -163,6 +172,83 @@ def test_convert_xlrd_book_to_openpyxl_uses_row_arrays_when_cell_access_breaks()
 
     assert workbook.active["A1"].value == "Header"
     assert workbook.active["A2"].value == 4
+
+
+def test_convert_xlrd_book_to_openpyxl_uses_sheet_visible_for_active_sheet():
+    xlrd = pytest.importorskip("xlrd")
+
+    book = _FakeBook(
+        [
+            _FakeSheet("First", rows=[[_FakeCell(xlrd.XL_CELL_TEXT, "a")]]),
+            _FakeSheet("Second", rows=[[_FakeCell(xlrd.XL_CELL_TEXT, "b")]], sheet_visible=1),
+            _FakeSheet("Hidden", rows=[[_FakeCell(xlrd.XL_CELL_TEXT, "c")]], visibility=1, sheet_visible=1),
+        ]
+    )
+
+    workbook = _convert_xlrd_book_to_openpyxl(book)
+
+    assert workbook.active.title == "Second"
+    assert resolve_sheet_names(workbook, requested=None, active_only=True) == ["Second"]
+
+
+def test_convert_xlrd_book_to_openpyxl_falls_back_to_first_visible_sheet():
+    xlrd = pytest.importorskip("xlrd")
+
+    book = _FakeBook(
+        [
+            _FakeSheet("First", rows=[[_FakeCell(xlrd.XL_CELL_TEXT, "a")]]),
+            _FakeSheet("Hidden", rows=[[_FakeCell(xlrd.XL_CELL_TEXT, "b")]], visibility=1),
+            _FakeSheet("Third", rows=[[_FakeCell(xlrd.XL_CELL_TEXT, "c")]], sheet_selected=1),
+        ]
+    )
+
+    workbook = _convert_xlrd_book_to_openpyxl(book)
+
+    assert workbook.active.title == "Third"
+
+    book = _FakeBook(
+        [
+            _FakeSheet("First", rows=[[_FakeCell(xlrd.XL_CELL_TEXT, "a")]]),
+            _FakeSheet("Hidden", rows=[[_FakeCell(xlrd.XL_CELL_TEXT, "b")]], visibility=1),
+            _FakeSheet("Third", rows=[[_FakeCell(xlrd.XL_CELL_TEXT, "c")]]),
+        ]
+    )
+    workbook = _convert_xlrd_book_to_openpyxl(book)
+
+    assert workbook.active.title == "First"
+
+
+def test_resolve_sheet_names_for_xls_uses_original_names_when_openpyxl_renames_duplicates():
+    xlrd = pytest.importorskip("xlrd")
+
+    book = _FakeBook(
+        [
+            _FakeSheet("Sheet", rows=[[_FakeCell(xlrd.XL_CELL_TEXT, "a")]]),
+            _FakeSheet("sheet", rows=[[_FakeCell(xlrd.XL_CELL_TEXT, "b")]]),
+        ]
+    )
+
+    workbook = _convert_xlrd_book_to_openpyxl(book)
+
+    assert workbook.sheetnames == ["Sheet", "sheet1"]
+    assert resolve_sheet_names(workbook, requested=["sheet"]) == ["sheet1"]
+
+
+def test_resolve_sheet_names_for_xls_excludes_hidden_requested_sheets():
+    xlrd = pytest.importorskip("xlrd")
+
+    book = _FakeBook(
+        [
+            _FakeSheet("Visible", rows=[[_FakeCell(xlrd.XL_CELL_TEXT, "a")]]),
+            _FakeSheet("Hidden", rows=[[_FakeCell(xlrd.XL_CELL_TEXT, "b")]], visibility=1),
+        ]
+    )
+
+    workbook = _convert_xlrd_book_to_openpyxl(book)
+
+    assert resolve_sheet_names(workbook, requested=None) == ["Visible"]
+    with pytest.raises(InputError, match="Worksheet\\(s\\) not found: Hidden"):
+        resolve_sheet_names(workbook, requested=["Hidden"])
 
 
 def test_resolve_sheet_names_rejects_active_only_when_no_visible_sheets():


### PR DESCRIPTION
## Summary
- preserve original .xls sheet metadata during conversion to openpyxl
- resolve requested and active-sheet selection against source .xls sheet names
- add unit and integration coverage for multi-sheet .xls selection behavior

## Testing
- .\\.venv\\Scripts\\python.exe -m pytest -q
