### PR TITLE
fix: optimize merged-table reconstruction caching

### DIFF
--- a/src/ade_engine/application/pipeline/pipeline.py
+++ b/src/ade_engine/application/pipeline/pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, List
 
@@ -317,18 +318,34 @@ def _collect_source_headers_by_column_name(tables: list[TableResult]) -> dict[st
     return headers_by_name
 
 
+@dataclass(frozen=True)
+class _MergedFrameMetadata:
+    column_names: list[str]
+    column_indexes_by_name: dict[str, int]
+    column_values_by_name: dict[str, list[Any]]
+
+
+def _build_merged_frame_metadata(merged_df: pl.DataFrame) -> _MergedFrameMetadata:
+    column_names = list(merged_df.columns)
+    return _MergedFrameMetadata(
+        column_names=column_names,
+        column_indexes_by_name={column_name: index for index, column_name in enumerate(column_names)},
+        column_values_by_name={column_name: merged_df.get_column(column_name).to_list() for column_name in column_names},
+    )
+
+
 def _build_merged_source_columns(
     *,
-    merged_df: pl.DataFrame,
+    merged_frame: _MergedFrameMetadata,
     headers_by_name: dict[str, list[Any]],
 ) -> list[SourceColumn]:
     source_columns: list[SourceColumn] = []
-    for index, column_name in enumerate(merged_df.columns):
+    for index, column_name in enumerate(merged_frame.column_names):
         source_columns.append(
             SourceColumn(
                 index=index,
                 header=_first_non_empty_header(headers_by_name.get(column_name, [])),
-                values=merged_df.get_column(column_name).to_list(),
+                values=merged_frame.column_values_by_name[column_name],
             )
         )
     return source_columns
@@ -337,19 +354,19 @@ def _build_merged_source_columns(
 def _build_merged_mapped_columns(
     *,
     tables: list[TableResult],
-    merged_df: pl.DataFrame,
+    merged_frame: _MergedFrameMetadata,
 ) -> list[MappedColumn]:
     merged_mapped: dict[str, MappedColumn] = {}
     for table_result in tables:
         for mapped in table_result.mapped_columns:
-            if mapped.field_name not in merged_df.columns:
+            merged_values = merged_frame.column_values_by_name.get(mapped.field_name)
+            if merged_values is None:
                 continue
-            merged_values = merged_df.get_column(mapped.field_name).to_list()
             existing = merged_mapped.get(mapped.field_name)
             if existing is None:
                 merged_mapped[mapped.field_name] = MappedColumn(
                     field_name=mapped.field_name,
-                    source_index=merged_df.columns.index(mapped.field_name),
+                    source_index=merged_frame.column_indexes_by_name[mapped.field_name],
                     header=mapped.header,
                     values=merged_values,
                     score=mapped.score,
@@ -370,7 +387,7 @@ def _build_merged_mapped_columns(
 def _build_merged_column_scores(
     *,
     tables: list[TableResult],
-    merged_df: pl.DataFrame,
+    merged_frame: _MergedFrameMetadata,
 ) -> dict[int, dict[str, float]]:
     merged_scores_by_name: dict[str, dict[str, float]] = {}
     for table_result in tables:
@@ -384,7 +401,7 @@ def _build_merged_column_scores(
                 merged_scores[field_name] = score if current is None else max(current, score)
 
     merged_scores: dict[int, dict[str, float]] = {}
-    for index, column_name in enumerate(merged_df.columns):
+    for index, column_name in enumerate(merged_frame.column_names):
         scores = merged_scores_by_name.get(column_name)
         if scores:
             merged_scores[index] = dict(scores)
@@ -402,11 +419,12 @@ def _build_merged_table_result(tables: list[TableResult], merged_df: pl.DataFram
     if any(table.sheet_index != sheet_index for table in tables):
         raise PipelineError("Failed to merge in-sheet tables: contributing tables span multiple sheet indexes")
 
+    merged_frame = _build_merged_frame_metadata(merged_df)
     headers_by_name = _collect_source_headers_by_column_name(tables)
-    source_columns = _build_merged_source_columns(merged_df=merged_df, headers_by_name=headers_by_name)
-    mapped_columns = _build_merged_mapped_columns(tables=tables, merged_df=merged_df)
+    source_columns = _build_merged_source_columns(merged_frame=merged_frame, headers_by_name=headers_by_name)
+    mapped_columns = _build_merged_mapped_columns(tables=tables, merged_frame=merged_frame)
     mapped_names = {column.field_name for column in mapped_columns}
-    unmapped_columns = [column for column in source_columns if merged_df.columns[column.index] not in mapped_names]
+    unmapped_columns = [column for column in source_columns if merged_frame.column_names[column.index] not in mapped_names]
     duplicate_unmapped_names: set[str] = set()
     for table_result in tables:
         for source_index in table_result.duplicate_unmapped_indices:
@@ -414,7 +432,7 @@ def _build_merged_table_result(tables: list[TableResult], merged_df: pl.DataFram
                 duplicate_unmapped_names.add(table_result.table.columns[source_index])
 
     duplicate_unmapped_indices = {
-        index for index, column_name in enumerate(merged_df.columns) if column_name in duplicate_unmapped_names
+        index for index, column_name in enumerate(merged_frame.column_names) if column_name in duplicate_unmapped_names
     }
 
     return TableResult(
@@ -426,7 +444,7 @@ def _build_merged_table_result(tables: list[TableResult], merged_df: pl.DataFram
         sheet_index=sheet_index,
         mapped_columns=mapped_columns,
         unmapped_columns=unmapped_columns,
-        column_scores=_build_merged_column_scores(tables=tables, merged_df=merged_df),
+        column_scores=_build_merged_column_scores(tables=tables, merged_frame=merged_frame),
         duplicate_unmapped_indices=duplicate_unmapped_indices,
         row_count=merged_df.height,
     )

--- a/tests/unit/test_pipeline_multi_table.py
+++ b/tests/unit/test_pipeline_multi_table.py
@@ -4,13 +4,13 @@ from openpyxl import Workbook
 import polars as pl
 import pytest
 
-from ade_engine.application.pipeline.pipeline import Pipeline, _merge_tables_in_sheet
+from ade_engine.application.pipeline.pipeline import Pipeline, _build_merged_table_result, _merge_tables_in_sheet
 from ade_engine.extensions.registry import Registry
 from ade_engine.infrastructure.observability.logger import NullLogger
 from ade_engine.infrastructure.settings import Settings
 from ade_engine.models.errors import PipelineError
 from ade_engine.models.extension_contexts import FieldDef, RowKind
-from ade_engine.models.table import SourceColumn, TableRegion, TableResult
+from ade_engine.models.table import MappedColumn, SourceColumn, TableRegion, TableResult
 
 
 def test_process_sheet_renders_multiple_tables_with_blank_row():
@@ -576,3 +576,63 @@ def test_merge_tables_in_sheet_preserves_duplicate_unmapped_indices():
     merged = _merge_tables_in_sheet([table_a, table_b])[0]
 
     assert merged.duplicate_unmapped_indices == {0}
+
+
+def test_build_merged_table_result_materializes_each_merged_column_once(monkeypatch: pytest.MonkeyPatch):
+    merged_df = pl.DataFrame(
+        {
+            "email": ["a@example.com", None],
+            "name": [None, "Alice"],
+        }
+    )
+    table_a = TableResult(
+        sheet_name="Sheet1",
+        table=pl.DataFrame({"email": ["a@example.com"]}),
+        source_region=TableRegion(min_row=1, min_col=1, max_row=2, max_col=1),
+        source_columns=[SourceColumn(index=0, header="Email", values=["a@example.com"])],
+        table_index=0,
+        sheet_index=0,
+        mapped_columns=[
+            MappedColumn(
+                field_name="email",
+                source_index=0,
+                header="Email",
+                values=["a@example.com"],
+                score=0.9,
+            )
+        ],
+        row_count=1,
+    )
+    table_b = TableResult(
+        sheet_name="Sheet1",
+        table=pl.DataFrame({"name": ["Alice"]}),
+        source_region=TableRegion(min_row=4, min_col=1, max_row=5, max_col=1),
+        source_columns=[SourceColumn(index=0, header="Name", values=["Alice"])],
+        table_index=1,
+        sheet_index=0,
+        mapped_columns=[
+            MappedColumn(
+                field_name="name",
+                source_index=0,
+                header="Name",
+                values=["Alice"],
+                score=0.8,
+            )
+        ],
+        row_count=1,
+    )
+
+    get_column_calls: dict[str, int] = {}
+    original_get_column = pl.DataFrame.get_column
+
+    def counting_get_column(self: pl.DataFrame, name: str) -> pl.Series:
+        if self is merged_df:
+            get_column_calls[name] = get_column_calls.get(name, 0) + 1
+        return original_get_column(self, name)
+
+    monkeypatch.setattr(pl.DataFrame, "get_column", counting_get_column)
+
+    merged = _build_merged_table_result([table_a, table_b], merged_df)
+
+    assert merged.table.columns == ["email", "name"]
+    assert get_column_calls == {"email": 1, "name": 1}


### PR DESCRIPTION
## Summary
- cache merged DataFrame column values and column indexes once per merged-table reconstruction
- reuse the shared metadata across source column, mapped column, and score rebuilding
- add a regression test that asserts each merged column is materialized at most once

Closes #23

## Testing
- .\\.venv\\Scripts\\python.exe -m pytest -q
- .\\.venv\\Scripts\\lint-imports.exe --config .importlinter