### PR TITLE
[codex] Expand gitignore for local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,27 @@
-.venv/
-__pycache__/
-.pytest_cache/
-*.pyc
+.DS_Store
 
+# Local environments
+.venv/
+
+# Python caches
+__pycache__/
+*.pyc
+*.pyo
+
+# Test and tooling caches
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.import_linter_cache/
+.coverage
+htmlcov/
+
+# Build artifacts
+build/
 dist/
-src/ade_engine.egg-info/
+*.egg-info/
+
+# Local ADE CLI outputs
+logs/
+output/
+tmp/


### PR DESCRIPTION
## What changed

- Expanded `.gitignore` to cover local ADE runtime outputs, common Python/tool caches, build artifacts, and macOS metadata.

## Why

- The repo was showing local-generated files like `logs/`, `output/`, `tmp/`, and `.DS_Store` as untracked noise.

## Impact
- Local development artifacts stay out of `git status` without changing tracked source files.

## Validation

- Verified `git ls-files -o --exclude-standard` returned no remaining untracked local artifacts after the update.




