### PR TITLE
Fix workbook loading for invalid stylesheet font family values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,27 @@
-.venv/
-__pycache__/
-.pytest_cache/
-*.pyc
+.DS_Store
 
+# Local environments
+.venv/
+
+# Python caches
+__pycache__/
+*.pyc
+*.pyo
+
+# Test and tooling caches
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.import_linter_cache/
+.coverage
+htmlcov/
+
+# Build artifacts
+build/
 dist/
-src/ade_engine.egg-info/
+*.egg-info/
+
+# Local ADE CLI outputs
+logs/
+output/
+tmp/

--- a/src/ade_engine/infrastructure/io/workbook.py
+++ b/src/ade_engine/infrastructure/io/workbook.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import csv
 import math
+import re
+from io import BytesIO
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+from zipfile import ZIP_DEFLATED, ZipFile
 
 import openpyxl
 from openpyxl import Workbook
@@ -52,7 +55,72 @@ def _load_openpyxl_workbook(path: Path) -> Workbook:
     try:
         return openpyxl.load_workbook(filename=path, read_only=True, data_only=True)
     except Exception as exc:  # pragma: no cover - openpyxl owns error types
+        repaired_workbook = _try_load_workbook_with_repaired_styles(path, exc)
+        if repaired_workbook is not None:
+            return repaired_workbook
         raise InputError(f"Failed to open workbook '{path}': {exc}") from exc
+
+
+def _try_load_workbook_with_repaired_styles(path: Path, exc: Exception) -> Workbook | None:
+    if not _is_invalid_font_family_stylesheet_error(exc):
+        return None
+
+    repaired_bytes = _repair_invalid_font_families_in_archive(path)
+    if repaired_bytes is None:
+        return None
+
+    try:
+        return openpyxl.load_workbook(filename=BytesIO(repaired_bytes), read_only=True, data_only=True)
+    except Exception:
+        return None
+
+
+def _is_invalid_font_family_stylesheet_error(exc: Exception) -> bool:
+    if "could not read stylesheet" not in str(exc):
+        return False
+
+    current: BaseException | None = exc
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if "Max value is 14" in str(current):
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
+def _repair_invalid_font_families_in_archive(path: Path) -> bytes | None:
+    with ZipFile(path) as archive:
+        try:
+            styles_xml = archive.read("xl/styles.xml")
+        except KeyError:
+            return None
+
+        repaired_styles_xml, changed = _remove_invalid_font_family_elements(styles_xml)
+        if not changed:
+            return None
+
+        buffer = BytesIO()
+        with ZipFile(buffer, "w", compression=ZIP_DEFLATED) as repaired_archive:
+            for member in archive.infolist():
+                data = repaired_styles_xml if member.filename == "xl/styles.xml" else archive.read(member.filename)
+                repaired_archive.writestr(member, data)
+        return buffer.getvalue()
+
+
+def _remove_invalid_font_family_elements(styles_xml: bytes) -> tuple[bytes, bool]:
+    pattern = re.compile(rb"<family\b[^>]*\bval=\"(\d+)\"[^>]*/>")
+    changed = False
+
+    def _replace(match: re.Match[bytes]) -> bytes:
+        nonlocal changed
+        family_value = int(match.group(1))
+        if family_value <= 14:
+            return match.group(0)
+        changed = True
+        return b""
+
+    return pattern.sub(_replace, styles_xml), changed
 
 
 def _load_xls_workbook(path: Path) -> Workbook:

--- a/tests/unit/test_workbook_io.py
+++ b/tests/unit/test_workbook_io.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from io import BytesIO
 from pathlib import Path
+from zipfile import ZIP_DEFLATED, ZipFile
 
 import pytest
 from openpyxl import Workbook
@@ -147,6 +149,34 @@ def test_load_source_workbook_reads_xls_into_workbook(tmp_path: Path):
     assert workbook.active["A1"].value == "Header"
     assert workbook.active["A2"].value == "USER@Example.com"
     workbook.close()
+
+
+def test_load_source_workbook_repairs_invalid_font_family_in_stylesheet(tmp_path: Path):
+    source = tmp_path / "input.xlsx"
+    workbook = Workbook()
+    sheet = workbook.active
+    assert sheet is not None
+    sheet.title = "Data"
+    sheet["A1"] = "Header"
+    sheet["A2"] = "Alice"
+    workbook.save(source)
+    workbook.close()
+
+    _corrupt_stylesheet_font_family(source, invalid_value=16)
+
+    loaded = load_source_workbook(source)
+
+    assert loaded.sheetnames == ["Data"]
+    assert loaded.active["A2"].value == "Alice"
+    loaded.close()
+
+
+def test_load_source_workbook_raises_input_error_for_other_openpyxl_failures(tmp_path: Path):
+    source = tmp_path / "broken.xlsx"
+    source.write_bytes(b"not a zip archive")
+
+    with pytest.raises(InputError, match="Failed to open workbook"):
+        load_source_workbook(source)
 
 
 def test_convert_xlrd_book_to_openpyxl_uses_row_arrays_when_cell_access_breaks():
@@ -298,3 +328,21 @@ def test_resolve_sheet_names_rejects_active_only_when_no_visible_sheets():
     with pytest.raises(InputError, match="No visible worksheets available"):
         resolve_sheet_names(workbook, requested=None, active_only=True)
 
+
+def _corrupt_stylesheet_font_family(path: Path, *, invalid_value: int) -> None:
+    buffer = BytesIO()
+    with ZipFile(path) as archive:
+        styles_xml = archive.read("xl/styles.xml")
+        corrupted_styles_xml = styles_xml.replace(
+            b'<family val="2" />',
+            f'<family val="{invalid_value}" />'.encode(),
+            1,
+        )
+        assert corrupted_styles_xml != styles_xml
+
+        with ZipFile(buffer, "w", compression=ZIP_DEFLATED) as rewritten:
+            for member in archive.infolist():
+                data = corrupted_styles_xml if member.filename == "xl/styles.xml" else archive.read(member.filename)
+                rewritten.writestr(member, data)
+
+    path.write_bytes(buffer.getvalue())

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "ade-engine"
-version = "1.7.9"
+version = "1.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "openpyxl" },


### PR DESCRIPTION
## Summary
- add a targeted workbook load fallback that repairs invalid `font/family` values in `xl/styles.xml` when `openpyxl` fails on that specific stylesheet error
- keep other workbook load failures unchanged so unrelated input errors still surface normally
- add unit coverage for the repaired malformed-workbook case and a non-repairable broken workbook case
- update `.gitignore` for local envs, caches, build artifacts, and ADE output directories
- bump the editable package version in `uv.lock`

## Testing
- `./.venv/bin/pytest -q /Users/mitchbrown/Developer/ade-engine/tests/unit/test_workbook_io.py`