### PR TITLE
[codex] Include derived field mappings in reporting

### DIFF
--- a/docs/callable-contracts.md
+++ b/docs/callable-contracts.md
@@ -149,3 +149,38 @@ Table hooks that may replace the DataFrame:
 - `on_table_validated`
 
 These hooks may return `pl.DataFrame` or `None`. All other hooks must return `None`.
+
+### Reporting derived field mappings
+
+Hooks and transforms that derive a registered field from an existing source column
+can report that provenance through `state` without adding a synthetic source
+column. The engine records these as `TableResult.derived_mappings`, counts the
+field as detected in `engine.run.completed` field rollups, and exposes the
+original source header on the field summary.
+
+Preferred engine-owned contract:
+
+```python
+state.setdefault("ade_engine", {}).setdefault("derived_mappings", []).append(
+    {
+        "field_name": "postal_code",
+        "source_header": "Address Line 1",
+        # optional when the header exists in the current source columns
+        "source_index": 0,
+        # optional scoping for multi-table/multi-sheet workbooks
+        "table_index": table_index,
+        "sheet_name": source_sheet.title,
+    }
+)
+```
+
+For compatibility, the engine also reads the existing config-package convention:
+
+```python
+state.setdefault("ade_config", {}).setdefault("mapping_overrides", {}).setdefault(
+    "original_header_overrides", {}
+)["postal_code"] = "Address Line 1"
+```
+
+Derived mappings affect field detection/reporting only. Physical column counts
+and `structure.columns` still describe only real source columns.

--- a/src/ade_engine/application/pipeline/pipeline.py
+++ b/src/ade_engine/application/pipeline/pipeline.py
@@ -18,7 +18,7 @@ from ade_engine.infrastructure.observability.logger import RunLogger
 from ade_engine.infrastructure.settings import Settings
 from ade_engine.models.errors import PipelineError
 from ade_engine.models.extension_contexts import HookName
-from ade_engine.models.table import MappedColumn, SourceColumn, TableRegion, TableResult
+from ade_engine.models.table import DerivedMapping, MappedColumn, SourceColumn, TableRegion, TableResult
 
 
 def _stringify_cell(value: Any) -> str | None:
@@ -144,6 +144,136 @@ def _apply_mapping_as_rename(
     if not rename_map:
         return table, {}
     return table.rename(rename_map), rename_map
+
+
+def _state_mapping_at_path(state: dict, path: tuple[str, ...]) -> Any:
+    current: Any = state
+    for key in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def _iter_derived_mapping_entries(state: dict) -> list[Any]:
+    entries: list[Any] = []
+
+    # Formal engine-owned contract for new config packages.
+    formal = _state_mapping_at_path(state, ("ade_engine", "derived_mappings"))
+    if isinstance(formal, list):
+        entries.extend(formal)
+    elif isinstance(formal, dict):
+        entries.append(formal)
+
+    # Backwards-compatible contract used by existing ADE config hooks.
+    overrides = _state_mapping_at_path(state, ("ade_config", "mapping_overrides", "original_header_overrides"))
+    if overrides is None and isinstance(state, dict):
+        dotted = state.get("ade_config.mapping_overrides")
+        if isinstance(dotted, dict):
+            overrides = dotted.get("original_header_overrides")
+
+    if isinstance(overrides, dict):
+        for field_name, source in overrides.items():
+            if isinstance(source, dict):
+                entry = dict(source)
+                entry.setdefault("field_name", field_name)
+                entries.append(entry)
+            else:
+                entries.append({"field_name": field_name, "source_header": source})
+    elif isinstance(overrides, list):
+        entries.extend(overrides)
+
+    return entries
+
+
+def _source_index_for_header(source_columns: list[SourceColumn], source_header: Any) -> int | None:
+    if source_header in (None, ""):
+        return None
+    wanted = str(source_header).strip()
+    if not wanted:
+        return None
+    for col in source_columns:
+        if col.header in (None, ""):
+            continue
+        if str(col.header).strip() == wanted:
+            return int(col.index)
+    return None
+
+
+def _coerce_optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_optional_float(value: Any, *, default: float) -> float:
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _collect_derived_mappings(
+    *,
+    state: dict,
+    table: pl.DataFrame,
+    source_columns: list[SourceColumn],
+    mapped_columns: list[MappedColumn],
+    sheet_name: str,
+    table_index: int,
+) -> list[DerivedMapping]:
+    physical_fields = {str(col.field_name) for col in mapped_columns}
+    table_fields = set(table.columns)
+    out: dict[str, DerivedMapping] = {}
+
+    for entry in _iter_derived_mapping_entries(state):
+        if not isinstance(entry, dict):
+            continue
+
+        scoped_table = _coerce_optional_int(entry.get("table_index"))
+        if entry.get("table_index") is not None and scoped_table is None:
+            continue
+        if scoped_table is not None and scoped_table != int(table_index):
+            continue
+        scoped_sheet = entry.get("sheet_name")
+        if scoped_sheet is not None and str(scoped_sheet) != str(sheet_name):
+            continue
+
+        field_name = entry.get("field_name", entry.get("field"))
+        source_header = entry.get("source_header", entry.get("original_header", entry.get("header")))
+        if field_name in (None, "") or source_header in (None, ""):
+            continue
+
+        field_text = str(field_name)
+        if field_text in physical_fields or field_text not in table_fields:
+            continue
+
+        source_index = entry.get("source_index")
+        if source_index is None:
+            source_index = _source_index_for_header(source_columns, source_header)
+        else:
+            source_index = _coerce_optional_int(source_index)
+
+        if source_index is None:
+            continue
+
+        score = _coerce_optional_float(entry.get("score"), default=1.0)
+        out[field_text] = DerivedMapping(
+            field_name=field_text,
+            source_header=source_header,
+            source_index=source_index,
+            score=score,
+        )
+
+    return sorted(
+        out.values(),
+        key=lambda mapping: (mapping.source_index if mapping.source_index is not None else 10**9, mapping.field_name),
+    )
 
 
 def _mapping_ratio(table_result: TableResult) -> float:
@@ -384,6 +514,34 @@ def _build_merged_mapped_columns(
     return sorted(merged_mapped.values(), key=lambda col: col.source_index)
 
 
+def _build_merged_derived_mappings(tables: list[TableResult]) -> list[DerivedMapping]:
+    merged: dict[str, DerivedMapping] = {}
+    for table_result in tables:
+        for mapping in getattr(table_result, "derived_mappings", []) or []:
+            existing = merged.get(mapping.field_name)
+            if existing is None:
+                merged[mapping.field_name] = DerivedMapping(
+                    field_name=mapping.field_name,
+                    source_header=mapping.source_header,
+                    source_index=mapping.source_index,
+                    score=mapping.score,
+                )
+                continue
+            score_candidates = [score for score in (existing.score, mapping.score) if score is not None]
+            source_header = existing.source_header if existing.source_header not in (None, "") else mapping.source_header
+            source_index = existing.source_index if existing.source_index is not None else mapping.source_index
+            merged[mapping.field_name] = DerivedMapping(
+                field_name=mapping.field_name,
+                source_header=source_header,
+                source_index=source_index,
+                score=max(score_candidates) if score_candidates else None,
+            )
+    return sorted(
+        merged.values(),
+        key=lambda mapping: (mapping.source_index if mapping.source_index is not None else 10**9, mapping.field_name),
+    )
+
+
 def _build_merged_column_scores(
     *,
     tables: list[TableResult],
@@ -423,6 +581,7 @@ def _build_merged_table_result(tables: list[TableResult], merged_df: pl.DataFram
     headers_by_name = _collect_source_headers_by_column_name(tables)
     source_columns = _build_merged_source_columns(merged_frame=merged_frame, headers_by_name=headers_by_name)
     mapped_columns = _build_merged_mapped_columns(tables=tables, merged_frame=merged_frame)
+    derived_mappings = _build_merged_derived_mappings(tables)
     mapped_names = {column.field_name for column in mapped_columns}
     unmapped_columns = [column for column in source_columns if merged_frame.column_names[column.index] not in mapped_names]
     duplicate_unmapped_names: set[str] = set()
@@ -443,6 +602,7 @@ def _build_merged_table_result(tables: list[TableResult], merged_df: pl.DataFram
         table_index=0,
         sheet_index=sheet_index,
         mapped_columns=mapped_columns,
+        derived_mappings=derived_mappings,
         unmapped_columns=unmapped_columns,
         column_scores=_build_merged_column_scores(tables=tables, merged_frame=merged_frame),
         duplicate_unmapped_indices=duplicate_unmapped_indices,
@@ -700,6 +860,15 @@ class Pipeline:
         if maybe_table is not None:
             table = maybe_table
 
+        derived_mappings = _collect_derived_mappings(
+            state=state,
+            table=table,
+            source_columns=source_cols,
+            mapped_columns=mapped_cols,
+            sheet_name=sheet.title,
+            table_index=table_index,
+        )
+
         table_result = TableResult(
             sheet_name=sheet.title,
             table=table,
@@ -708,6 +877,7 @@ class Pipeline:
             table_index=table_index,
             sheet_index=int(metadata.get("sheet_index", 0)) if isinstance(metadata, dict) else 0,
             mapped_columns=mapped_cols,
+            derived_mappings=derived_mappings,
             unmapped_columns=unmapped_cols,
             column_scores=scores_by_column,
             duplicate_unmapped_indices=set(duplicate_unmapped_indices),

--- a/src/ade_engine/application/run_completion_report.py
+++ b/src/ade_engine/application/run_completion_report.py
@@ -424,6 +424,9 @@ class RunCompletionReportBuilder:
         detected_fields = self._detected_fields_in_table(table, expected_fields)
         detected_count = len(detected_fields)
         not_detected_count = max(0, len(expected_fields) - detected_count)
+        field_occ = self._field_occurrences_init(expected_fields)
+        self._accumulate_table_field_occurrences(field_occ, expected_fields, table)
+        fields = self._field_summaries(expected_fields, field_occ)
 
         counts = Counts(
             rows=RowsCount(total=source_row_count, empty=empty_rows),
@@ -477,6 +480,7 @@ class RunCompletionReportBuilder:
             ),
             counts=counts,
             validation=validation,
+            fields=fields,
             structure=structure,
             outputs=outputs,
         )
@@ -604,6 +608,9 @@ class RunCompletionReportBuilder:
     def _detected_fields_in_table(self, table: TableResult, expected_fields: list[Any]) -> set[str]:
         expected = set(self._expected_field_names(expected_fields))
         detected = {str(getattr(c, "field_name", "") or "") for c in (getattr(table, "mapped_columns", []) or [])}
+        detected.update(
+            str(getattr(c, "field_name", "") or "") for c in (getattr(table, "derived_mappings", []) or [])
+        )
         return {f for f in detected if f in expected}
 
     def _rollup_sheet(self, expected_fields: list[Any], tables: list[TableSummary]) -> tuple[Counts, Validation, list[FieldSummary]]:
@@ -689,6 +696,8 @@ class RunCompletionReportBuilder:
                 occ["tables"] += f.occurrences.tables
                 occ["columns"] += f.occurrences.columns
                 occ["best"] = max(occ["best"], float(f.best_mapping_score or 0.0))
+                occ["derived"] = bool(occ["derived"] or f.derived)
+                occ["source_headers"].update(f.source_headers)
 
         validation.max_severity = _max_severity(validation.issues_by_severity)
         fields = self._field_summaries(expected_fields, field_occ)
@@ -750,6 +759,8 @@ class RunCompletionReportBuilder:
                 occ["tables"] += f.occurrences.tables
                 occ["columns"] += f.occurrences.columns
                 occ["best"] = max(occ["best"], float(f.best_mapping_score or 0.0))
+                occ["derived"] = bool(occ["derived"] or f.derived)
+                occ["source_headers"].update(f.source_headers)
 
         validation.max_severity = _max_severity(validation.issues_by_severity)
         fields = self._field_summaries(expected_fields, field_occ)
@@ -783,8 +794,49 @@ class RunCompletionReportBuilder:
         out: dict[str, dict[str, Any]] = {}
         for f in expected_fields:
             name = str(getattr(f, "name", "") or "")
-            out[name] = {"tables": 0, "columns": 0, "best": 0.0}
+            out[name] = {"tables": 0, "columns": 0, "best": 0.0, "derived": False, "source_headers": set()}
         return out
+
+    def _accumulate_table_field_occurrences(
+        self,
+        occ: dict[str, dict[str, Any]],
+        expected_fields: list[Any],
+        table: TableResult,
+    ) -> None:
+        expected_names = set(self._expected_field_names(expected_fields))
+        seen_in_table: set[str] = set()
+
+        for col in getattr(table, "mapped_columns", []) or []:
+            field_name = str(getattr(col, "field_name", "") or "")
+            if field_name not in expected_names:
+                continue
+            record = occ.get(field_name)
+            if record is None:
+                continue
+            record["columns"] += 1
+            record["best"] = max(record["best"], float(getattr(col, "score", None) or 0.0))
+            header = getattr(col, "header", None)
+            if header not in (None, ""):
+                record["source_headers"].add(str(header))
+            seen_in_table.add(field_name)
+
+        for mapping in getattr(table, "derived_mappings", []) or []:
+            field_name = str(getattr(mapping, "field_name", "") or "")
+            if field_name not in expected_names:
+                continue
+            record = occ.get(field_name)
+            if record is None:
+                continue
+            record["columns"] += 1
+            record["best"] = max(record["best"], float(getattr(mapping, "score", None) or 1.0))
+            record["derived"] = True
+            source_header = getattr(mapping, "source_header", None)
+            if source_header not in (None, ""):
+                record["source_headers"].add(str(source_header))
+            seen_in_table.add(field_name)
+
+        for field in seen_in_table:
+            occ[field]["tables"] += 1
 
     def _accumulate_field_occurrences(
         self, occ: dict[str, dict[str, Any]], expected_fields: list[Any], tables: list[TableSummary]
@@ -803,7 +855,25 @@ class RunCompletionReportBuilder:
                     continue
                 record["columns"] += 1
                 record["best"] = max(record["best"], float(m.score or 0.0))
+                if col.header.raw is not None:
+                    record["source_headers"].add(col.header.raw)
                 seen_in_table.add(m.field)
+            for f in t.fields:
+                if f.field not in expected_names or not f.detected:
+                    continue
+                record = occ.get(f.field)
+                if record is None:
+                    continue
+                # Only add fields that were not already represented by a
+                # physical mapped source column for this table. This preserves
+                # physical column counts while allowing derived mappings to
+                # participate in field rollups.
+                if f.field not in seen_in_table:
+                    record["columns"] += f.occurrences.columns
+                    record["best"] = max(record["best"], float(f.best_mapping_score or 0.0))
+                    seen_in_table.add(f.field)
+                record["derived"] = bool(record["derived"] or f.derived)
+                record["source_headers"].update(f.source_headers)
             for field in seen_in_table:
                 occ[field]["tables"] += 1
 
@@ -819,7 +889,9 @@ class RunCompletionReportBuilder:
                     field=name,
                     label=str(label) if label is not None else None,
                     detected=detected,
+                    derived=bool(rec.get("derived", False)) if detected else False,
                     best_mapping_score=float(rec["best"]) if detected else None,
+                    source_headers=sorted(str(h) for h in rec.get("source_headers", set())) if detected else [],
                     occurrences=FieldOccurrences(tables=int(rec["tables"]), columns=int(rec["columns"])),
                 )
             )

--- a/src/ade_engine/models/__init__.py
+++ b/src/ade_engine/models/__init__.py
@@ -36,7 +36,7 @@ from ade_engine.models.extension_outputs import (
     RowDetectorResult,
 )
 from ade_engine.models.run import RunError, RunErrorCode, RunRequest, RunResult, RunStatus
-from ade_engine.models.table import MappedColumn, SourceColumn, TableRegion, TableResult
+from ade_engine.models.table import DerivedMapping, MappedColumn, SourceColumn, TableRegion, TableResult
 
 __all__ = [
     "AdeEngineError",
@@ -75,6 +75,7 @@ __all__ = [
     "RunStatus",
     "SourceColumn",
     "MappedColumn",
+    "DerivedMapping",
     "TableRegion",
     "TableResult",
 ]

--- a/src/ade_engine/models/events.py
+++ b/src/ade_engine/models/events.py
@@ -329,15 +329,25 @@ class FieldSummary(StrictModel):
     field: str
     label: str | None = None
     detected: bool
+    derived: bool = False
     best_mapping_score: NonNegativeFloat | None = None
+    source_headers: list[str] = Field(default_factory=list)
     occurrences: FieldOccurrences
 
     @model_validator(mode="after")
     def _field_ok(self) -> "FieldSummary":
+        if self.source_headers != sorted(self.source_headers):
+            raise ValueError("source_headers must be sorted")
+        if len(set(self.source_headers)) != len(self.source_headers):
+            raise ValueError("source_headers must not contain duplicates")
         if self.detected and self.best_mapping_score is None:
             raise ValueError("best_mapping_score must be set when detected==true")
         if not self.detected and self.best_mapping_score is not None:
             raise ValueError("best_mapping_score must be null when detected==false")
+        if not self.detected and self.derived:
+            raise ValueError("derived must be false when detected==false")
+        if not self.detected and self.source_headers:
+            raise ValueError("source_headers must be empty when detected==false")
         return self
 
 
@@ -512,8 +522,14 @@ class TableSummary(StrictModel):
     locator: TableLocator
     counts: Counts
     validation: Validation
+    fields: list[FieldSummary] = Field(default_factory=list)
     structure: TableStructure
     outputs: Outputs | None = None
+
+    @model_validator(mode="after")
+    def _fields_ok(self) -> "TableSummary":
+        _validate_fields_rollup(self.fields, self.counts, scope="table")
+        return self
 
 
 class SheetScan(StrictModel):

--- a/src/ade_engine/models/table.py
+++ b/src/ade_engine/models/table.py
@@ -99,6 +99,20 @@ class MappedColumn:
 
 
 @dataclass
+class DerivedMapping:
+    """Logical field mapping produced by hooks/transforms.
+
+    Derived mappings report fields created from an existing source column without
+    adding a synthetic physical column to ``source_columns``.
+    """
+
+    field_name: str
+    source_header: Any
+    source_index: int | None = None
+    score: float | None = None
+
+
+@dataclass
 class TableResult:
     """Processed table facts for reporting/debugging.
 
@@ -112,6 +126,7 @@ class TableResult:
     table_index: int = 0
     sheet_index: int = 0
     mapped_columns: list[MappedColumn] = field(default_factory=list)
+    derived_mappings: list[DerivedMapping] = field(default_factory=list)
     unmapped_columns: list[SourceColumn] = field(default_factory=list)
     column_scores: dict[int, dict[str, float]] = field(default_factory=dict)
     duplicate_unmapped_indices: set[int] = field(default_factory=set)
@@ -120,7 +135,10 @@ class TableResult:
     output_sheet_name: str | None = None
 
     def mapping_lookup(self) -> dict[str, int | None]:
-        return {col.field_name: col.source_index for col in self.mapped_columns}
+        out: dict[str, int | None] = {col.field_name: col.source_index for col in self.mapped_columns}
+        for mapping in self.derived_mappings:
+            out.setdefault(mapping.field_name, mapping.source_index)
+        return out
 
 
-__all__ = ["SourceColumn", "MappedColumn", "TableRegion", "TableResult"]
+__all__ = ["SourceColumn", "MappedColumn", "DerivedMapping", "TableRegion", "TableResult"]

--- a/tests/unit/test_pipeline_multi_table.py
+++ b/tests/unit/test_pipeline_multi_table.py
@@ -127,6 +127,59 @@ def test_process_sheet_sorts_tables_by_mapping_ratio():
     ]
 
 
+def test_process_sheet_records_derived_mapping_from_state_override():
+    registry = Registry()
+    logger = NullLogger()
+
+    registry.register_field(FieldDef(name="address_line1"))
+    registry.register_field(FieldDef(name="postal_code"))
+
+    def detector(*, row_index, **_):
+        if row_index == 1:
+            return {RowKind.HEADER.value: 1.0}
+        return {RowKind.DATA.value: 1.0}
+
+    def detect_address(*, column_header_original, **_):
+        return {"address_line1": 1.0} if column_header_original == "Address Line 1" else {}
+
+    def derive_postal_code(*, state, table_index, **_):
+        state.setdefault("ade_config", {}).setdefault("mapping_overrides", {}).setdefault(
+            "original_header_overrides", {}
+        )["postal_code"] = "Address Line 1"
+        return pl.lit("V1A 2B3")
+
+    registry.register_row_detector(detector, row_kind=RowKind.UNKNOWN.value, priority=0)
+    registry.register_column_detector(detect_address, field="address_line1", priority=0)
+    registry.register_column_transform(derive_postal_code, field="postal_code", priority=0)
+    registry.finalize()
+
+    pipeline = Pipeline(registry=registry, settings=Settings(), logger=logger)
+
+    source_wb = Workbook()
+    source_ws = source_wb.active
+    source_ws.title = "Sheet1"
+    source_ws.append(["Address Line 1"])
+    source_ws.append(["123 Main St V1A 2B3"])
+
+    output_wb = Workbook()
+    output_wb.remove(output_wb.active)
+    output_ws = output_wb.create_sheet(title="Sheet1")
+
+    tables = pipeline.process_sheet(
+        sheet=source_ws,
+        output_sheet=output_ws,
+        state={},
+        metadata={"input_file": "input.xlsx", "sheet_index": 0},
+        input_file_name="input.xlsx",
+    )
+
+    assert len(tables) == 1
+    assert [column.header for column in tables[0].source_columns] == ["Address Line 1"]
+    assert [(mapping.field_name, mapping.source_header, mapping.source_index) for mapping in tables[0].derived_mappings] == [
+        ("postal_code", "Address Line 1", 0)
+    ]
+
+
 def test_process_sheet_handles_mixed_numeric_types():
     registry = Registry()
     logger = NullLogger()

--- a/tests/unit/test_run_completion_report.py
+++ b/tests/unit/test_run_completion_report.py
@@ -6,9 +6,11 @@ from pathlib import Path
 import polars as pl
 
 from ade_engine.application.run_completion_report import RunCompletionReportBuilder
+from ade_engine.extensions.registry import Registry
 from ade_engine.infrastructure.settings import Settings
+from ade_engine.models.extension_contexts import FieldDef
 from ade_engine.models.run import RunStatus
-from ade_engine.models.table import SourceColumn, TableRegion, TableResult
+from ade_engine.models.table import DerivedMapping, MappedColumn, SourceColumn, TableRegion, TableResult
 
 
 def test_run_completion_report_allows_hooks_to_filter_rows() -> None:
@@ -51,3 +53,78 @@ def test_run_completion_report_allows_hooks_to_filter_rows() -> None:
     assert table_summary.counts.cells is not None
     assert table_summary.counts.cells.total == 12
     assert table_summary.counts.cells.non_empty == 10
+
+
+def test_run_completion_report_counts_derived_mappings_without_synthetic_columns() -> None:
+    builder = RunCompletionReportBuilder(input_file=Path("input.xlsx"), settings=Settings())
+    registry = Registry()
+    registry.register_field(FieldDef(name="address_line1", label="Address Line 1"))
+    registry.register_field(FieldDef(name="postal_code", label="Postal Code"))
+    builder.set_registry(registry)
+
+    source_columns = [
+        SourceColumn(index=0, header="Address Line 1", values=["123 Main St V1A 2B3"]),
+    ]
+
+    table = pl.DataFrame(
+        {
+            "address_line1": ["123 Main St"],
+            "postal_code": ["V1A 2B3"],
+        }
+    )
+
+    builder.record_table(
+        TableResult(
+            sheet_name="Sheet1",
+            sheet_index=0,
+            table_index=0,
+            source_region=TableRegion(min_row=1, min_col=1, max_row=2, max_col=1),
+            source_columns=source_columns,
+            table=table,
+            row_count=table.height,
+            mapped_columns=[
+                MappedColumn(
+                    field_name="address_line1",
+                    source_index=0,
+                    header="Address Line 1",
+                    values=["123 Main St V1A 2B3"],
+                    score=0.92,
+                )
+            ],
+            derived_mappings=[
+                DerivedMapping(
+                    field_name="postal_code",
+                    source_header="Address Line 1",
+                    source_index=0,
+                    score=1.0,
+                )
+            ],
+        )
+    )
+
+    payload = builder.build(
+        run_status=RunStatus.SUCCEEDED,
+        started_at=datetime.now(timezone.utc),
+        completed_at=datetime.now(timezone.utc),
+        error=None,
+        output_path=None,
+        output_written=False,
+    )
+
+    table_summary = payload.workbooks[0].sheets[0].tables[0]
+    assert table_summary.counts.columns.total == 1
+    assert table_summary.counts.columns.mapped == 1
+    assert table_summary.counts.fields.detected == 2
+    assert len(table_summary.structure.columns) == 1
+
+    fields = {field.field: field for field in table_summary.fields}
+    assert fields["postal_code"].detected is True
+    assert fields["postal_code"].derived is True
+    assert fields["postal_code"].source_headers == ["Address Line 1"]
+    assert fields["postal_code"].occurrences.columns == 1
+
+    run_fields = {field.field: field for field in payload.fields}
+    assert payload.counts.fields.detected == 2
+    assert run_fields["postal_code"].detected is True
+    assert run_fields["postal_code"].derived is True
+    assert run_fields["postal_code"].source_headers == ["Address Line 1"]

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "ade-engine"
-version = "1.9.1"
+version = "1.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "openpyxl" },


### PR DESCRIPTION
## Summary

Adds engine-supported reporting for derived field mappings so hooks and transforms can report fields derived from existing source headers without inventing synthetic source columns.

## Changes

- Adds `DerivedMapping` to `TableResult` and exports it from `ade_engine.models`.
- Reads derived mapping provenance from the new `state["ade_engine"]["derived_mappings"]` contract.
- Preserves compatibility with `state["ade_config"]["mapping_overrides"]["original_header_overrides"]`.
- Includes derived mappings in `engine.run.completed` field detection and rollups.
- Adds table-level field summaries with `derived` and `source_headers` metadata.
- Counts validation issues on derived fields against the physical source column's `valid_cells` using row-level de-duplication.
- Documents the new contract and adds focused regression coverage.

## Release Please

This branch contains a Conventional Commit that should trigger release-please when merged:

`feat(reporting): include derived field mappings`

## Validation

- `uv run pytest` -> 75 passed
- `git diff --check` -> clean