### PR TITLE
fix(reporting): valid cells and mapped columns

### DIFF
--- a/src/ade_engine/application/pipeline/pipeline.py
+++ b/src/ade_engine/application/pipeline/pipeline.py
@@ -277,11 +277,18 @@ def _collect_derived_mappings(
 
 
 def _mapping_ratio(table_result: TableResult) -> float:
-    total_cols = len(getattr(table_result, "source_columns", []) or [])
-    if total_cols <= 0:
+    non_empty_source_indices = {
+        int(col.index) for col in (getattr(table_result, "source_columns", []) or []) if not col.is_empty
+    }
+    mappable_cols = len(non_empty_source_indices)
+    if mappable_cols <= 0:
         return 0.0
-    mapped_cols = len(getattr(table_result, "mapped_columns", []) or [])
-    return mapped_cols / total_cols
+    mapped_cols = sum(
+        1
+        for col in (getattr(table_result, "mapped_columns", []) or [])
+        if int(col.source_index) in non_empty_source_indices
+    )
+    return mapped_cols / mappable_cols
 
 
 def _sort_tables_by_mapping_ratio(tables: list[TableResult]) -> list[TableResult]:

--- a/src/ade_engine/application/run_completion_report.py
+++ b/src/ade_engine/application/run_completion_report.py
@@ -375,7 +375,8 @@ class RunCompletionReportBuilder:
 
             values = list(getattr(col, "values", []) or [])
             non_empty_cells = sum(1 for v in values if not _is_empty_cell(v))
-            if non_empty_cells == 0:
+            source_column_empty = bool(getattr(col, "is_empty", False))
+            if source_column_empty:
                 empty_cols += 1
             non_empty_cells_total += non_empty_cells
 
@@ -387,29 +388,19 @@ class RunCompletionReportBuilder:
                 duplicate_unmapped=duplicate_unmapped,
             )
 
-            if status_bucket == "mapped":
-                mapped_count += 1
-            else:
-                unmapped_count += 1
+            if not source_column_empty:
+                if status_bucket == "mapped":
+                    mapped_count += 1
+                else:
+                    unmapped_count += 1
 
             valid_cells = None
             if mapping.status == "mapped" and mapping.field is not None:
-                validation_fields = self._validation_fields_for_source_column(
+                valid_cells = self._valid_cells_for_final_field(
                     table=table,
-                    col_index=int(col.index),
-                    header_raw=raw_header,
-                    mapped_field=mapping.field,
+                    field=mapping.field,
+                    invalid_rows_by_field=invalid_rows_by_field,
                 )
-                invalid_rows: set[int] = set()
-                validated = False
-                for field in validation_fields:
-                    rows = invalid_rows_by_field.get(field)
-                    if rows is None:
-                        continue
-                    validated = True
-                    invalid_rows.update(rows)
-                if validated:
-                    valid_cells = max(0, int(non_empty_cells) - len(invalid_rows))
 
             columns.append(
                 ColumnStructure(
@@ -615,35 +606,21 @@ class RunCompletionReportBuilder:
 
         return invalid
 
-    def _validation_fields_for_source_column(
+    def _valid_cells_for_final_field(
         self,
         *,
         table: TableResult,
-        col_index: int,
-        header_raw: str | None,
-        mapped_field: str,
-    ) -> list[str]:
-        fields = [mapped_field]
-        seen = {mapped_field}
-        header_key = header_raw.strip() if header_raw is not None else None
+        field: str,
+        invalid_rows_by_field: dict[str, set[int]],
+    ) -> int | None:
+        df = getattr(table, "table", None)
+        if not isinstance(df, pl.DataFrame) or field not in df.columns:
+            return None
 
-        for mapping in getattr(table, "derived_mappings", []) or []:
-            field_name = str(getattr(mapping, "field_name", "") or "")
-            if not field_name or field_name in seen:
-                continue
-
-            source_index = getattr(mapping, "source_index", None)
-            if source_index is not None and int(source_index) == col_index:
-                fields.append(field_name)
-                seen.add(field_name)
-                continue
-
-            source_header = getattr(mapping, "source_header", None)
-            if header_key is not None and source_header not in (None, "") and str(source_header).strip() == header_key:
-                fields.append(field_name)
-                seen.add(field_name)
-
-        return fields
+        values = df.get_column(field).to_list()
+        non_empty = sum(1 for value in values if not _is_empty_cell(value))
+        invalid_rows = invalid_rows_by_field.get(field, set())
+        return max(0, int(non_empty) - len(invalid_rows))
 
     # ------------------------------------------------------------------
     # Rollups
@@ -741,6 +718,7 @@ class RunCompletionReportBuilder:
                     continue
                 occ["tables"] += f.occurrences.tables
                 occ["columns"] += f.occurrences.columns
+                occ["valid_cells"] += int(f.valid_cells)
                 occ["best"] = max(occ["best"], float(f.best_mapping_score or 0.0))
                 occ["derived"] = bool(occ["derived"] or f.derived)
                 occ["source_headers"].update(f.source_headers)
@@ -804,6 +782,7 @@ class RunCompletionReportBuilder:
                     continue
                 occ["tables"] += f.occurrences.tables
                 occ["columns"] += f.occurrences.columns
+                occ["valid_cells"] += int(f.valid_cells)
                 occ["best"] = max(occ["best"], float(f.best_mapping_score or 0.0))
                 occ["derived"] = bool(occ["derived"] or f.derived)
                 occ["source_headers"].update(f.source_headers)
@@ -840,7 +819,14 @@ class RunCompletionReportBuilder:
         out: dict[str, dict[str, Any]] = {}
         for f in expected_fields:
             name = str(getattr(f, "name", "") or "")
-            out[name] = {"tables": 0, "columns": 0, "best": 0.0, "derived": False, "source_headers": set()}
+            out[name] = {
+                "tables": 0,
+                "columns": 0,
+                "valid_cells": 0,
+                "best": 0.0,
+                "derived": False,
+                "source_headers": set(),
+            }
         return out
 
     def _accumulate_table_field_occurrences(
@@ -851,6 +837,7 @@ class RunCompletionReportBuilder:
     ) -> None:
         expected_names = set(self._expected_field_names(expected_fields))
         seen_in_table: set[str] = set()
+        valid_cells_by_field = self._valid_cells_by_field(table, expected_names)
 
         for col in getattr(table, "mapped_columns", []) or []:
             field_name = str(getattr(col, "field_name", "") or "")
@@ -883,6 +870,7 @@ class RunCompletionReportBuilder:
 
         for field in seen_in_table:
             occ[field]["tables"] += 1
+            occ[field]["valid_cells"] += valid_cells_by_field.get(field, 0)
 
     def _accumulate_field_occurrences(
         self, occ: dict[str, dict[str, Any]], expected_fields: list[Any], tables: list[TableSummary]
@@ -910,6 +898,7 @@ class RunCompletionReportBuilder:
                 record = occ.get(f.field)
                 if record is None:
                     continue
+                record["valid_cells"] += int(f.valid_cells)
                 # Only add fields that were not already represented by a
                 # physical mapped source column for this table. This preserves
                 # physical column counts while allowing derived mappings to
@@ -928,7 +917,7 @@ class RunCompletionReportBuilder:
         for f in expected_fields:
             name = str(getattr(f, "name", "") or "")
             label = getattr(f, "label", None)
-            rec = occ.get(name) or {"tables": 0, "columns": 0, "best": 0.0}
+            rec = occ.get(name) or {"tables": 0, "columns": 0, "valid_cells": 0, "best": 0.0}
             detected = bool(rec["tables"] > 0)
             out.append(
                 FieldSummary(
@@ -936,11 +925,28 @@ class RunCompletionReportBuilder:
                     label=str(label) if label is not None else None,
                     detected=detected,
                     derived=bool(rec.get("derived", False)) if detected else False,
+                    valid_cells=int(rec.get("valid_cells", 0)) if detected else 0,
                     best_mapping_score=float(rec["best"]) if detected else None,
                     source_headers=sorted(str(h) for h in rec.get("source_headers", set())) if detected else [],
                     occurrences=FieldOccurrences(tables=int(rec["tables"]), columns=int(rec["columns"])),
                 )
             )
+        return out
+
+    def _valid_cells_by_field(self, table: TableResult, expected_names: set[str]) -> dict[str, int]:
+        df = getattr(table, "table", None)
+        if not isinstance(df, pl.DataFrame) or df.height == 0:
+            return {}
+
+        invalid_rows_by_field = self._invalid_cell_rows_by_field(table)
+        out: dict[str, int] = {}
+        for field in expected_names:
+            if field not in df.columns:
+                continue
+            values = df.get_column(field).to_list()
+            non_empty = sum(1 for value in values if not _is_empty_cell(value))
+            invalid_rows = invalid_rows_by_field.get(field, set())
+            out[field] = max(0, int(non_empty) - len(invalid_rows))
         return out
 
     # ------------------------------------------------------------------

--- a/src/ade_engine/models/events.py
+++ b/src/ade_engine/models/events.py
@@ -254,11 +254,13 @@ class ColumnsCount(StrictModel):
         if self.empty > self.total:
             raise ValueError("columns.empty must be <= columns.total")
 
-        if any(x > self.total for x in (self.mapped, self.unmapped)):
-            raise ValueError("column mapping counts must be <= columns.total")
+        non_empty = self.total - self.empty
 
-        if (self.mapped + self.unmapped) != self.total:
-            raise ValueError("columns.(mapped+unmapped) must equal columns.total")
+        if any(x > non_empty for x in (self.mapped, self.unmapped)):
+            raise ValueError("column mapping counts must be <= non-empty columns")
+
+        if (self.mapped + self.unmapped) != non_empty:
+            raise ValueError("columns.(mapped+unmapped) must equal columns.total - columns.empty")
 
         return self
 
@@ -330,6 +332,7 @@ class FieldSummary(StrictModel):
     label: str | None = None
     detected: bool
     derived: bool = False
+    valid_cells: NonNegativeInt = 0
     best_mapping_score: NonNegativeFloat | None = None
     source_headers: list[str] = Field(default_factory=list)
     occurrences: FieldOccurrences
@@ -346,6 +349,8 @@ class FieldSummary(StrictModel):
             raise ValueError("best_mapping_score must be null when detected==false")
         if not self.detected and self.derived:
             raise ValueError("derived must be false when detected==false")
+        if not self.detected and self.valid_cells != 0:
+            raise ValueError("valid_cells must be 0 when detected==false")
         if not self.detected and self.source_headers:
             raise ValueError("source_headers must be empty when detected==false")
         return self

--- a/src/ade_engine/models/table.py
+++ b/src/ade_engine/models/table.py
@@ -88,6 +88,18 @@ class SourceColumn:
     header: Any
     values: list[Any]
 
+    @staticmethod
+    def _is_empty_cell(value: Any) -> bool:
+        if value is None:
+            return True
+        if isinstance(value, str):
+            return value.strip() == ""
+        return False
+
+    @property
+    def is_empty(self) -> bool:
+        return self._is_empty_cell(self.header) and all(self._is_empty_cell(value) for value in self.values)
+
 
 @dataclass
 class MappedColumn:

--- a/tests/unit/test_run_completion_report.py
+++ b/tests/unit/test_run_completion_report.py
@@ -122,15 +122,191 @@ def test_run_completion_report_counts_derived_mappings_without_synthetic_columns
     assert fields["postal_code"].derived is True
     assert fields["postal_code"].source_headers == ["Address Line 1"]
     assert fields["postal_code"].occurrences.columns == 1
+    assert fields["postal_code"].valid_cells == 1
 
     run_fields = {field.field: field for field in payload.fields}
     assert payload.counts.fields.detected == 2
     assert run_fields["postal_code"].detected is True
     assert run_fields["postal_code"].derived is True
     assert run_fields["postal_code"].source_headers == ["Address Line 1"]
+    assert run_fields["postal_code"].valid_cells == 1
 
 
-def test_run_completion_report_counts_derived_validation_against_source_column() -> None:
+def test_run_completion_report_maps_against_non_empty_source_columns() -> None:
+    builder = RunCompletionReportBuilder(input_file=Path("input.xlsx"), settings=Settings())
+
+    source_columns = [
+        SourceColumn(index=0, header="Email", values=["alice@example.com", "bob@example.com"]),
+        SourceColumn(index=1, header="Notes", values=["keep", "review"]),
+        SourceColumn(index=2, header=None, values=[None, ""]),
+    ]
+
+    table = pl.DataFrame(
+        {
+            "email": ["alice@example.com", "bob@example.com"],
+            "Notes": ["keep", "review"],
+            "col_3": [None, ""],
+        }
+    )
+
+    builder.record_table(
+        TableResult(
+            sheet_name="Sheet1",
+            sheet_index=0,
+            table_index=0,
+            source_region=TableRegion(min_row=1, min_col=1, max_row=3, max_col=3),
+            source_columns=source_columns,
+            table=table,
+            row_count=table.height,
+            mapped_columns=[
+                MappedColumn(
+                    field_name="email",
+                    source_index=0,
+                    header="Email",
+                    values=["alice@example.com", "bob@example.com"],
+                    score=1.0,
+                )
+            ],
+        )
+    )
+
+    payload = builder.build(
+        run_status=RunStatus.SUCCEEDED,
+        started_at=datetime.now(timezone.utc),
+        completed_at=datetime.now(timezone.utc),
+        error=None,
+        output_path=None,
+        output_written=False,
+    )
+
+    columns = payload.workbooks[0].sheets[0].tables[0].counts.columns
+    assert columns.total == 3
+    assert columns.empty == 1
+    assert columns.mapped == 1
+    assert columns.unmapped == 1
+
+
+def test_run_completion_report_counts_valid_cells_on_final_fields() -> None:
+    builder = RunCompletionReportBuilder(input_file=Path("input.xlsx"), settings=Settings())
+    registry = Registry()
+    registry.register_field(FieldDef(name="full_name", label="Full Name"))
+    registry.register_field(FieldDef(name="first_name", label="First Name"))
+    registry.register_field(FieldDef(name="middle_name", label="Middle Name"))
+    registry.register_field(FieldDef(name="last_name", label="Last Name"))
+    builder.set_registry(registry)
+
+    source_columns = [
+        SourceColumn(
+            index=0,
+            header="Full Name",
+            values=[
+                "Alice Beth Smith",
+                "Brian Carl Jones",
+                "Cara Dana Brown",
+                "Devin Evan Green",
+                "Ella Faye White",
+                "Finn Gray Black",
+                "Gina Hope Stone",
+            ],
+        ),
+    ]
+
+    table = pl.DataFrame(
+        {
+            "full_name": source_columns[0].values,
+            "first_name": ["Alice", "Brian", "Cara", "Devin", "Ella", "Finn", "Gina"],
+            "middle_name": ["Beth", "Carl", "Dana", "Evan", "Faye", "Gray", "Hope"],
+            "last_name": ["Smith", "Jones", "Brown", "Green", "White", "Black", "Stone"],
+        }
+    )
+
+    builder.record_table(
+        TableResult(
+            sheet_name="Sheet1",
+            sheet_index=0,
+            table_index=0,
+            source_region=TableRegion(min_row=1, min_col=1, max_row=8, max_col=1),
+            source_columns=source_columns,
+            table=table,
+            row_count=table.height,
+            mapped_columns=[
+                MappedColumn(
+                    field_name="full_name",
+                    source_index=0,
+                    header="Full Name",
+                    values=source_columns[0].values,
+                    score=1.0,
+                )
+            ],
+            derived_mappings=[
+                DerivedMapping(field_name="first_name", source_header="Full Name", source_index=0, score=1.0),
+                DerivedMapping(field_name="middle_name", source_header="Full Name", source_index=0, score=1.0),
+                DerivedMapping(field_name="last_name", source_header="Full Name", source_index=0, score=1.0),
+            ],
+        )
+    )
+
+    payload = builder.build(
+        run_status=RunStatus.SUCCEEDED,
+        started_at=datetime.now(timezone.utc),
+        completed_at=datetime.now(timezone.utc),
+        error=None,
+        output_path=None,
+        output_written=False,
+    )
+
+    fields = {field.field: field for field in payload.fields}
+    assert fields["full_name"].valid_cells == 7
+    assert fields["first_name"].valid_cells == 7
+    assert fields["middle_name"].valid_cells == 7
+    assert fields["last_name"].valid_cells == 7
+
+
+def test_run_completion_report_counts_column_valid_cells_from_final_field_values() -> None:
+    builder = RunCompletionReportBuilder(input_file=Path("input.xlsx"), settings=Settings())
+
+    source_columns = [
+        SourceColumn(index=0, header="Email", values=["alice@example.com", "not an email"]),
+    ]
+
+    table = pl.DataFrame({"email": ["alice@example.com", None]})
+
+    builder.record_table(
+        TableResult(
+            sheet_name="Sheet1",
+            sheet_index=0,
+            table_index=0,
+            source_region=TableRegion(min_row=1, min_col=1, max_row=3, max_col=1),
+            source_columns=source_columns,
+            table=table,
+            row_count=table.height,
+            mapped_columns=[
+                MappedColumn(
+                    field_name="email",
+                    source_index=0,
+                    header="Email",
+                    values=source_columns[0].values,
+                    score=1.0,
+                )
+            ],
+        )
+    )
+
+    payload = builder.build(
+        run_status=RunStatus.SUCCEEDED,
+        started_at=datetime.now(timezone.utc),
+        completed_at=datetime.now(timezone.utc),
+        error=None,
+        output_path=None,
+        output_written=False,
+    )
+
+    column = payload.workbooks[0].sheets[0].tables[0].structure.columns[0]
+    assert column.non_empty_cells == 2
+    assert column.valid_cells == 1
+
+
+def test_run_completion_report_counts_mapped_column_validation_on_final_field_only() -> None:
     builder = RunCompletionReportBuilder(input_file=Path("input.xlsx"), settings=Settings())
     registry = Registry()
     registry.register_field(FieldDef(name="full_name", label="Full Name"))
@@ -189,6 +365,4 @@ def test_run_completion_report_counts_derived_validation_against_source_column()
     table_summary = payload.workbooks[0].sheets[0].tables[0]
     assert len(table_summary.structure.columns) == 1
     assert table_summary.structure.columns[0].header.raw == "Full Name"
-    # Both derived validators fail on the second row, but the physical source
-    # cell should only be counted invalid once.
-    assert table_summary.structure.columns[0].valid_cells == 1
+    assert table_summary.structure.columns[0].valid_cells == 2

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "ade-engine"
-version = "1.9.2"
+version = "1.9.6"
 source = { editable = "." }
 dependencies = [
     { name = "openpyxl" },


### PR DESCRIPTION
## Summary

- Counts mapped-column `valid_cells` from the final canonical field values instead of original source-column values.
- Keeps derived fields detected and counted in field rollups, including valid-cell totals.
- Preserves source-column structure counts while treating empty source columns consistently.

## Why

Valid-cell reporting should reflect the normalized output fields users inspect, not just the raw input column that produced them. This matters when one source field, such as `Full Name`, produces final fields like `first_name` and `last_name`.

## Validation

- `uv run pytest -q`